### PR TITLE
Wither Goggles fix

### DIFF
--- a/items/WITHER_GOGGLES.json
+++ b/items/WITHER_GOGGLES.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:skull",
   "displayname": "§5Wither Goggles",
-  "nbttag": "{HideFlags:254,SkullOwner:{Id:\"a4baabfd-565a-33f1-a52b-b120cb7c749b\",Properties:{textures:[0:{Value:\"ewogICJ0aW1lc3RhbXAiIDogMTYwNTU0MzM0MTg4MSwKICAicHJvZmlsZUlkIiA6ICJiMGQ0YjI4YmMxZDc0ODg5YWYwZTg2NjFjZWU5NmFhYiIsCiAgInByb2ZpbGVOYW1lIiA6ICJNaW5lU2tpbl9vcmciLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzdjZWI4ZjA3NThlMmQ4YWM0OWRlNmY5Nzc2MDNjN2JmYzIzZmQ4MmE4NTc0ODEwYTQ1ZjVlOTdjNjQzNmQ3OSIKICAgIH0KICB9Cn0\u003d\"}]}},display:{Lore:[0:\"§7Gear Score: §d255\",1:\"§7Ability Damage: §c+45%\",2:\"§7Intelligence: §a+300 \",3:\"\",4:\"§7§8This item can be reforged!\",5:\"§aPerfect 52500 / 52500\",6:\"§7§4❣ §cRequires §aCatacombs Level 28\",7:\"§5§lEPIC DUNGEON HELMET\"],Name:\"§5Wither Goggles\"},ExtraAttributes:{id:\"WITHER_GOGGLES\",shop_dungeon_floor_completion_required:6}}",
+  "nbttag": "{HideFlags:254,SkullOwner:{Id:\"a4baabfd-565a-33f1-a52b-b120cb7c749b\",Properties:{textures:[0:{Value:\"ewogICJ0aW1lc3RhbXAiIDogMTYwNTU0MzM0MTg4MSwKICAicHJvZmlsZUlkIiA6ICJiMGQ0YjI4YmMxZDc0ODg5YWYwZTg2NjFjZWU5NmFhYiIsCiAgInByb2ZpbGVOYW1lIiA6ICJNaW5lU2tpbl9vcmciLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzdjZWI4ZjA3NThlMmQ4YWM0OWRlNmY5Nzc2MDNjN2JmYzIzZmQ4MmE4NTc0ODEwYTQ1ZjVlOTdjNjQzNmQ3OSIKICAgIH0KICB9Cn0\u003d\"}]}},display:{Lore:[0:\"§7Gear Score: §d255\",1:\"§7Ability Damage: §c+45%\",2:\"§7Intelligence: §a+300 \",3:\"\",4:\"§7§8This item can be reforged!\",5:\"§aPerfect 52500 / 52500\",6:\"§7§4❣ §cRequires §aFloor VI Completion\",7:\"§5§lEPIC DUNGEON HELMET\"],Name:\"§5Wither Goggles\"},ExtraAttributes:{id:\"WITHER_GOGGLES\",shop_dungeon_floor_completion_required:6}}",
   "damage": 3,
   "lore": [
     "§7Gear Score: §d255",
@@ -10,7 +10,7 @@
     "",
     "§7§8This item can be reforged!",
     "§aPerfect 52500 / 52500",
-    "§7§4❣ §cRequires §aCatacombs Level 28",
+    "§7§4❣ §cRequires §aFloor VI Completion",
     "§5§lEPIC DUNGEON HELMET"
   ],
   "internalname": "WITHER_GOGGLES",


### PR DESCRIPTION
Wither Goggles no longer require Catacombs 28 but now a Floor 6 completion 