### PR TITLE
remove crafting recipe for all magma armor pieces

### DIFF
--- a/items/ARMOR_OF_MAGMA_BOOTS.json
+++ b/items/ARMOR_OF_MAGMA_BOOTS.json
@@ -17,7 +17,7 @@
     "§5§lEPIC BOOTS"
   ],
   "internalname": "ARMOR_OF_MAGMA_BOOTS",
-  "clickcommand": "viewrecipe",
+  "clickcommand": "",
   "modver": "2.0.0-REL",
   "infoType": "WIKI_URL",
   "info": [

--- a/items/ARMOR_OF_MAGMA_BOOTS.json
+++ b/items/ARMOR_OF_MAGMA_BOOTS.json
@@ -16,17 +16,6 @@
     "§7§8This item can be reforged!",
     "§5§lEPIC BOOTS"
   ],
-  "recipe": {
-    "A1": "ENCHANTED_MAGMA_CREAM:12",
-    "A2": "",
-    "A3": "ENCHANTED_MAGMA_CREAM:12",
-    "B1": "ENCHANTED_MAGMA_CREAM:12",
-    "B2": "",
-    "B3": "ENCHANTED_MAGMA_CREAM:12",
-    "C1": "",
-    "C2": "",
-    "C3": ""
-  },
   "internalname": "ARMOR_OF_MAGMA_BOOTS",
   "clickcommand": "viewrecipe",
   "modver": "2.0.0-REL",

--- a/items/ARMOR_OF_MAGMA_CHESTPLATE.json
+++ b/items/ARMOR_OF_MAGMA_CHESTPLATE.json
@@ -20,19 +20,8 @@
     "§7§8This item can be reforged!",
     "§5§lEPIC CHESTPLATE"
   ],
-  "recipe": {
-    "A1": "ENCHANTED_MAGMA_CREAM:12",
-    "A2": "",
-    "A3": "ENCHANTED_MAGMA_CREAM:12",
-    "B1": "ENCHANTED_MAGMA_CREAM:12",
-    "B2": "ENCHANTED_MAGMA_CREAM:12",
-    "B3": "ENCHANTED_MAGMA_CREAM:12",
-    "C1": "ENCHANTED_MAGMA_CREAM:12",
-    "C2": "ENCHANTED_MAGMA_CREAM:12",
-    "C3": "ENCHANTED_MAGMA_CREAM:12"
-  },
   "internalname": "ARMOR_OF_MAGMA_CHESTPLATE",
-  "clickcommand": "viewrecipe",
+  "clickcommand": "",
   "modver": "2.0.0-REL",
   "infoType": "WIKI_URL",
   "info": [

--- a/items/ARMOR_OF_MAGMA_HELMET.json
+++ b/items/ARMOR_OF_MAGMA_HELMET.json
@@ -16,19 +16,8 @@
     "§7§8This item can be reforged!",
     "§5§lEPIC HELMET"
   ],
-  "recipe": {
-    "A1": "ENCHANTED_MAGMA_CREAM:12",
-    "A2": "ENCHANTED_MAGMA_CREAM:12",
-    "A3": "ENCHANTED_MAGMA_CREAM:12",
-    "B1": "ENCHANTED_MAGMA_CREAM:12",
-    "B2": "",
-    "B3": "ENCHANTED_MAGMA_CREAM:12",
-    "C1": "",
-    "C2": "",
-    "C3": ""
-  },
   "internalname": "ARMOR_OF_MAGMA_HELMET",
-  "clickcommand": "viewrecipe",
+  "clickcommand": "",
   "modver": "2.0.0-REL",
   "infoType": "WIKI_URL",
   "info": [

--- a/items/ARMOR_OF_MAGMA_LEGGINGS.json
+++ b/items/ARMOR_OF_MAGMA_LEGGINGS.json
@@ -16,19 +16,8 @@
     "§7§8This item can be reforged!",
     "§5§lEPIC LEGGINGS"
   ],
-  "recipe": {
-    "A1": "ENCHANTED_MAGMA_CREAM:12",
-    "A2": "ENCHANTED_MAGMA_CREAM:12",
-    "A3": "ENCHANTED_MAGMA_CREAM:12",
-    "B1": "ENCHANTED_MAGMA_CREAM:12",
-    "B2": "",
-    "B3": "ENCHANTED_MAGMA_CREAM:12",
-    "C1": "ENCHANTED_MAGMA_CREAM:12",
-    "C2": "",
-    "C3": "ENCHANTED_MAGMA_CREAM:12"
-  },
   "internalname": "ARMOR_OF_MAGMA_LEGGINGS",
-  "clickcommand": "viewrecipe",
+  "clickcommand": "",
   "modver": "2.0.0-REL",
   "infoType": "WIKI_URL",
   "info": [


### PR DESCRIPTION
It can no longer be crafted as also written in the community wiki https://hypixel-skyblock.fandom.com/wiki/Armor_of_Magma