### PR TITLE
Silver fang unlock criteria

### DIFF
--- a/items/SILVER_FANG.json
+++ b/items/SILVER_FANG.json
@@ -27,5 +27,5 @@
   "info": [
     "https://hypixel-skyblock.fandom.com/wiki/Silver_Fang"
   ],
-  "crafttext": "Requires: Ghast Tear VI"
+  "crafttext": "Requires: Ghast Tear V"
 }


### PR DESCRIPTION
Supposed to unlock at ghast tear 5 not 6