### PR TITLE
added mappings for the et/hex overlays

### DIFF
--- a/constants/enchants.json
+++ b/constants/enchants.json
@@ -825,7 +825,8 @@
       30
     ],
     "flame": [
-      25
+      25,
+      0
     ],
     "infinite_quiver": [
       10,
@@ -1437,5 +1438,13 @@
     "efficiency": 5,
     "harvesting": 5,
     "piscary": 5
-  }
+  },
+  "enchant_mapping_id": [
+    "prosecute",
+    "dragon_tracer"
+  ],
+  "enchant_mapping_item" : [
+    "PROSECUTE",
+    "aiming"
+  ]
 }


### PR DESCRIPTION
"enchant_mapping_id" has the enchant name on the book in lower case underscored i.e. Dragon Tracer -> dragon_tracer

"enchant_mapping_item" has the enchant id that shows on the item i.e. whatever the fuck hypixel wants to annoy us with

The enchants have to be in the same index between both arrays 