### PR TITLE
Fix incorrect potato item sell at farm merchant

### DIFF
--- a/items/FARM_MERCHANT_NPC.json
+++ b/items/FARM_MERCHANT_NPC.json
@@ -39,7 +39,7 @@
       "cost": [
         "SKYBLOCK_COIN:7"
       ],
-      "result": "POTATO:3"
+      "result": "POTATO_ITEM:3"
     },
     {
       "type": "npc_shop",


### PR DESCRIPTION
This was a really weird bug to find.

In Skyblock, there are:
* Potato aka `POTATO_ITEM`: https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/blob/master/items/POTATO_ITEM.json
* Potatoes aka `POTATO`: https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/blob/master/items/POTATO.json

Potatoes is a bugged item from when Potato Spreading was released: https://hypixel-skyblock.fandom.com/wiki/Potato_Spreading#Bugs
The NPC is said to sell these Potatoes, when in fact, they sell Potato, not Potatoes.

You can tell NEU has this incorrect as the Potatoes item in game has a BIN of 100k on auction house, but a craft cost of 2.3 coins.
The real potato item cannot be sold on the auction house, only on the bazaar.

Potatoes (bugged item):
![image](https://user-images.githubusercontent.com/16708907/222268339-6d966a50-d2f5-4978-95b8-e86b6d5079a7.png)

Potato:
![image](https://user-images.githubusercontent.com/16708907/222268422-85460db2-5d97-4c11-b7ed-83b265645f2e.png)
