### PR TITLE
Add Garden NPCs

### DIFF
--- a/items/ANDREW_NPC.json
+++ b/items/ANDREW_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Andrew (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzgyMmQ4ZTc1MWM4ZjJmZDRjODk0MmM0NGJkYjJmNWNhNGQ4YWU4ZTU3NWVkM2ViMzRjMThhODZlOTNiIn19fQ\u003d\u003d\"}]},Name:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\"},display:{Name:\"§9Andrew (NPC)\"},ExtraAttributes:{id:\"ANDREW_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "ANDREW_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 38,
+  "y": 69,
+  "z": -47,
+  "island": "hub"
+}

--- a/items/ARTHUR_NPC.json
+++ b/items/ARTHUR_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Arthur (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"518e6022-6a6c-2976-9e35-b47f01fbe460\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2NjMmU4MTk5MDZlYjE3OTQzOWI4ZGQ1NTUxMTMyZTU0ZWI0NzE3M2UwZjQ1ODg2MWFkMmE4YzkzNzkxODM4OTEifX19\"}]},Name:\"518e6022-6a6c-2976-9e35-b47f01fbe460\"},display:{Name:\"§9Arthur (NPC)\"},ExtraAttributes:{id:\"ARTHUR_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "ARTHUR_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 52,
+  "y": 72,
+  "z": -136,
+  "island": "hub"
+}

--- a/items/BANKER_BROADJAW_NPC.json
+++ b/items/BANKER_BROADJAW_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Banker Broadjaw (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"1f2d0eeb-d6e6-2c6a-8393-ee2133562b2b\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2U1OWY4YzRkZmQxYzU4M2E4YTU0ZmE1Y2M3ZjhlYjZjMjRkMjY5YWYyN2M5OWZkOWYyYjJiYmY0MGU3MGZlZDIifX19\"}]},Name:\"1f2d0eeb-d6e6-2c6a-8393-ee2133562b2b\"},display:{Name:\"§9Banker Broadjaw (NPC)\"},ExtraAttributes:{id:\"BANKER_BROADJAW_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "BANKER_BROADJAW_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 14,
+  "y": 202,
+  "z": -148,
+  "island": "mining_3"
+}

--- a/items/BETH_NPC.json
+++ b/items/BETH_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Beth (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"5c1bd8e1-514d-28a5-8ba5-9b85f774eee2\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2NhYmIyYzA0NjM1YTI5YjA4ZTE2MWQ4NTliMTFiZGFkYjc1YTI5ZDNjNjRkZjdlODRhMTA4YzM3ZjdmODNjMCJ9fX0\u003d\"}]},Name:\"5c1bd8e1-514d-28a5-8ba5-9b85f774eee2\"},display:{Name:\"§9Beth (NPC)\"},ExtraAttributes:{id:\"BETH_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "BETH_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 164,
+  "y": 78,
+  "z": -359,
+  "island": "farming_1"
+}

--- a/items/CLERK_SERAPHINE_NPC.json
+++ b/items/CLERK_SERAPHINE_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Clerk Seraphine (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"cd78c907-35ad-2414-9c1b-041682856bd7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2NkNjU0NTMxODE2ZWM3MjAwYTZhNDYxZDdhMDNjMmRhZGYzMWY0NDlhNTkxYzg1ZjNiMzFjYjJhODNkZDczNjYifX19\"}]},Name:\"cd78c907-35ad-2414-9c1b-041682856bd7\"},display:{Name:\"§9Clerk Seraphine (NPC)\"},ExtraAttributes:{id:\"CLERK_SERAPHINE_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "CLERK_SERAPHINE_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 12,
+  "y": 72,
+  "z": -101,
+  "island": "hub"
+}

--- a/items/DALBREK_NPC.json
+++ b/items/DALBREK_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Dalbrek (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzgyMmQ4ZTc1MWM4ZjJmZDRjODk0MmM0NGJkYjJmNWNhNGQ4YWU4ZTU3NWVkM2ViMzRjMThhODZlOTNiIn19fQ\u003d\u003d\"}]},Name:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\"},display:{Name:\"§9Dalbrek (NPC)\"},ExtraAttributes:{id:\"DALBREK_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "DALBREK_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 191,
+  "y": 217,
+  "z": 154,
+  "island": "mining_3"
+}

--- a/items/DUKE_NPC.json
+++ b/items/DUKE_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Duke (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzgyMmQ4ZTc1MWM4ZjJmZDRjODk0MmM0NGJkYjJmNWNhNGQ4YWU4ZTU3NWVkM2ViMzRjMThhODZlOTNiIn19fQ\u003d\u003d\"}]},Name:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\"},display:{Name:\"§9Duke (NPC)\"},ExtraAttributes:{id:\"DUKE_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "DUKE_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -7,
+  "y": 71,
+  "z": -90,
+  "island": "hub"
+}

--- a/items/DUSK_NPC.json
+++ b/items/DUSK_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Dusk (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"1d20b7e9-4518-2032-86b4-81ec14e9d2d8\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzdjYTg1YzE1NjNiZjU2OWQ4OGJmN2JjMzc1Y2JjODIwZDdkNGE3M2M5MmFhZjdkOTQ3OWFmNWVmNTI1NWQwNDAifX19\"}]},Name:\"1d20b7e9-4518-2032-86b4-81ec14e9d2d8\"},display:{Name:\"§9Dusk (NPC)\"},ExtraAttributes:{id:\"DUSK_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "DUSK_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -37,
+  "y": 69,
+  "z": -125,
+  "island": "hub"
+}

--- a/items/EMISSARY_CARLTON_NPC.json
+++ b/items/EMISSARY_CARLTON_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Emissary Carlton (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"9b7ba7c0-fcbe-2fc2-a810-39191402df1c\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2M3NjVmZWU5N2JjZmFlN2MxMzZiNmE2YjhjYTk1MzgxYWY5NjRkNmFlYmMwOGJmZGQyMzUwYWY3OGUyY2Y1MWEifX19\"}]},Name:\"9b7ba7c0-fcbe-2fc2-a810-39191402df1c\"},display:{Name:\"§9Emissary Carlton (NPC)\"},ExtraAttributes:{id:\"EMISSARY_CARLTON_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "EMISSARY_CARLTON_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -72,
+  "y": 154,
+  "z": -10,
+  "island": "mining_3"
+}

--- a/items/EMISSARY_CEANNA_NPC.json
+++ b/items/EMISSARY_CEANNA_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Emissary Ceanna (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"fd6a1e9b-5d04-2070-b3bd-9dcf47856aca\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2U3OGMyNWFjOGQ3OTNhNzNhZjMxZTVkYTNlOGJmMmQ2M2E2YzAwMjZmZGU5YTk2ODJmYzljYWY2MTU1NDBjNzkifX19\"}]},Name:\"fd6a1e9b-5d04-2070-b3bd-9dcf47856aca\"},display:{Name:\"§9Emissary Ceanna (NPC)\"},ExtraAttributes:{id:\"EMISSARY_CEANNA_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "EMISSARY_CEANNA_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 43,
+  "y": 136,
+  "z": 23,
+  "island": "mining_3"
+}

--- a/items/EMISSARY_ELIZA_NPC.json
+++ b/items/EMISSARY_ELIZA_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Emissary Eliza (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"e3c0180b-ada3-2283-97fb-426b4ce366e6\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzNhZjYxM2U0ZDgxMTBhZTNkZjYxZTFkZWUwYzA4YzM1ZDdiOTAyZmE1ZGYyYWFlMDI3NzljOTEyZDMxZTM5MTQifX19\"}]},Name:\"e3c0180b-ada3-2283-97fb-426b4ce366e6\"},display:{Name:\"§9Emissary Eliza (NPC)\"},ExtraAttributes:{id:\"EMISSARY_ELIZA_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "EMISSARY_ELIZA_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -37,
+  "y": 201,
+  "z": -131,
+  "island": "mining_3"
+}

--- a/items/EMISSARY_FRAISER_NPC.json
+++ b/items/EMISSARY_FRAISER_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Emissary Fraiser (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"b1a5364a-0eeb-27e4-97ce-49201e3a9dde\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzlhNDMzMjI1MTFmNGJiYTcxMGJkNzhjOThjOTBlODNhYzkyYTJkYTBmMDVhMGE2OTUxMDg5YmFjZTBjZjIwM2EifX19\"}]},Name:\"b1a5364a-0eeb-27e4-97ce-49201e3a9dde\"},display:{Name:\"§9Emissary Fraiser (NPC)\"},ExtraAttributes:{id:\"EMISSARY_FRAISER_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "EMISSARY_FRAISER_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -132,
+  "y": 175,
+  "z": -50,
+  "island": "mining_3"
+}

--- a/items/EMISSARY_LILITH_NPC.json
+++ b/items/EMISSARY_LILITH_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Emissary Lilith (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"04152855-8399-21dd-a862-b78a0a03ae3a\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzM4ZGZhYjJhOTNlNWI1MDMwMDAzY2RiMWUzYWI4MmMxMTVhZTFmY2E3NWI0NWQ3NTZlMjc0ZTBhZjJhZjVmNTAifX19\"}]},Name:\"04152855-8399-21dd-a862-b78a0a03ae3a\"},display:{Name:\"§9Emissary Lilith (NPC)\"},ExtraAttributes:{id:\"EMISSARY_LILITH_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "EMISSARY_LILITH_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 59,
+  "y": 199,
+  "z": -8,
+  "island": "mining_3"
+}

--- a/items/EMISSARY_SISKO_NPC.json
+++ b/items/EMISSARY_SISKO_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Emissary Sisko (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"604f050e-018f-24c8-854f-860eb4b9284c\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzhlYmY5Y2FjNWFiNDc5MDNlMWQyZDRjMjRmNjg1YTY2N2YyMDVmOWE2MTc3ZjZhNzYyMWY4NDcxOWU0ODc0NjUifX19\"}]},Name:\"604f050e-018f-24c8-854f-860eb4b9284c\"},display:{Name:\"§9Emissary Sisko (NPC)\"},ExtraAttributes:{id:\"EMISSARY_SISKO_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "EMISSARY_SISKO_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 496,
+  "y": 107,
+  "z": 557,
+  "island": "crystal_hollows"
+}

--- a/items/EMISSARY_WILSON_NPC.json
+++ b/items/EMISSARY_WILSON_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Emissary Wilson (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"43f3d0e2-3357-2ef3-9c44-353bcc3a7c7b\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2UxMTcyYjE3ZWIzMzE4Yjg0MWZhOTRiZTBiOGZiZDBiN2NkZGI1YWRkMWQyYjM1YWQ1ZTZhZGM4YWI3ZDUyMDYifX19\"}]},Name:\"43f3d0e2-3357-2ef3-9c44-353bcc3a7c7b\"},display:{Name:\"§9Emissary Wilson (NPC)\"},ExtraAttributes:{id:\"EMISSARY_WILSON_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "EMISSARY_WILSON_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 172,
+  "y": 151,
+  "z": 32,
+  "island": "mining_3"
+}

--- a/items/FARMER_JON_NPC.json
+++ b/items/FARMER_JON_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Farmer Jon (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"fa3e882d-e350-2e81-92d0-f76528c2e505\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzI4MjkwNGQzYzRmY2U4MjkxNzE4ZGFlOTA5OTVlMTM3Mzg3MWNiNjllMjI4Y2MyMDQ0OTU2MjBhMWEwZWM1MGEifX19\"}]},Name:\"fa3e882d-e350-2e81-92d0-f76528c2e505\"},display:{Name:\"§9Farmer Jon (NPC)\"},ExtraAttributes:{id:\"FARMER_JON_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "FARMER_JON_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 168,
+  "y": 92,
+  "z": -598,
+  "island": "farming_1"
+}

--- a/items/FARMHAND_NPC.json
+++ b/items/FARMHAND_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Farmhand (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzgyMmQ4ZTc1MWM4ZjJmZDRjODk0MmM0NGJkYjJmNWNhNGQ4YWU4ZTU3NWVkM2ViMzRjMThhODZlOTNiIn19fQ\u003d\u003d\"}]},Name:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\"},display:{Name:\"§9Farmhand (NPC)\"},ExtraAttributes:{id:\"FARMHAND_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "FARMHAND_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 144,
+  "y": 74,
+  "z": -241,
+  "island": "farming_1"
+}

--- a/items/FELIX_NPC.json
+++ b/items/FELIX_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Felix (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzgyMmQ4ZTc1MWM4ZjJmZDRjODk0MmM0NGJkYjJmNWNhNGQ4YWU4ZTU3NWVkM2ViMzRjMThhODZlOTNiIn19fQ\u003d\u003d\"}]},Name:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\"},display:{Name:\"§9Felix (NPC)\"},ExtraAttributes:{id:\"FELIX_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "FELIX_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -26,
+  "y": 69,
+  "z": -104,
+  "island": "hub"
+}

--- a/items/FISHERMAN_NPC.json
+++ b/items/FISHERMAN_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Fisherman (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"fc34813c-81ca-250c-8364-b061e09de9f6\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2E2NzVmMDcxZWZiMGNmMjdiZjE2MDgxZTNmODJmOWI1ZjhhZTg4ZWNhOWVlOTUyM2I2MjE2ZTYxN2Y2ZjQ1YzkifX19\"}]},Name:\"fc34813c-81ca-250c-8364-b061e09de9f6\"},display:{Name:\"§9Fisherman (NPC)\"},ExtraAttributes:{id:\"FISHERMAN_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "FISHERMAN_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 156,
+  "y": 69,
+  "z": 48,
+  "island": "hub"
+}

--- a/items/FRAGILIS_NPC.json
+++ b/items/FRAGILIS_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Fragilis (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"51054052-eae3-2a39-98ae-2f67ffe0e3b6\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzMwNzIyYzAwMGFlZTBiYmEzMDU4YjQyNWZlNWVlYWM3NjZlMGEwYzNjM2E3ZWRmNDI5YWQxNGUxNTI5N2RkMzMifX19\"}]},Name:\"51054052-eae3-2a39-98ae-2f67ffe0e3b6\"},display:{Name:\"§9Fragilis (NPC)\"},ExtraAttributes:{id:\"FRAGILIS_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "FRAGILIS_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 88,
+  "y": 200,
+  "z": -108,
+  "island": "mining_3"
+}

--- a/items/FRIENDLY_HIKER_NPC.json
+++ b/items/FRIENDLY_HIKER_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Friendly Hiker (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"4d5f7c28-d4b7-2ae1-8cbd-40420a55db9e\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2MzNWEyMGY1NzgwYzY2N2M1ZjU3NmJhNjMwN2RiNjFiMzVhM2M5ZjNhZGM2YTg2NTQ1NDcyNWY0ZTc3YTExMiJ9fX0\u003d\"}]},Name:\"4d5f7c28-d4b7-2ae1-8cbd-40420a55db9e\"},display:{Name:\"§9Friendly Hiker (NPC)\"},ExtraAttributes:{id:\"FRIENDLY_HIKER_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "FRIENDLY_HIKER_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 182,
+  "y": 78,
+  "z": -381,
+  "island": "farming_1"
+}

--- a/items/GIMLEY_NPC.json
+++ b/items/GIMLEY_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Gimley (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"b25614e3-9ad8-2f42-ade1-e656e740d692\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzU3YjM1NTJjNWFmMmFiMmRjNGUxZjg0ZDc4Y2E0YzRkNjc2ZGVjMDY4MTU3MjI1YTNjMjY3NGU1NTc0ZDIzNDgifX19\"}]},Name:\"b25614e3-9ad8-2f42-ade1-e656e740d692\"},display:{Name:\"§9Gimley (NPC)\"},ExtraAttributes:{id:\"GIMLEY_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "GIMLEY_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 29,
+  "y": 203,
+  "z": -149,
+  "island": "mining_3"
+}

--- a/items/GRANDMA_WOLF_NPC.json
+++ b/items/GRANDMA_WOLF_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Grandma Wolf (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"59d8ec1f-2f3c-21fe-aaf0-cb50a0606451\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzgzOTE5M2MwOWJjYWQ5ZDFmOTAxYWZlZjRlMmMwY2FkODNhYWUxYTU3MDMzNWMzZWNiYzdkMDVmZGUxOTg3OTUifX19\"}]},Name:\"59d8ec1f-2f3c-21fe-aaf0-cb50a0606451\"},display:{Name:\"§9Grandma Wolf (NPC)\"},ExtraAttributes:{id:\"GRANDMA_WOLF_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "GRANDMA_WOLF_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -281,
+  "y": 123,
+  "z": -190,
+  "island": "combat_1"
+}

--- a/items/GUY_NPC.json
+++ b/items/GUY_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Guy (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"803a98f0-8fa9-2be9-9823-fcb97018e321\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2U5ZTIzYmU3ZjA0NTU2ZmEzMzM1MWE0Yzc3MWEzZjA1ZjRhNmQyN2RlNDEzYTM2ZDAyMzBjNjFmNzE2OTg3OTkifX19\"}]},Name:\"803a98f0-8fa9-2be9-9823-fcb97018e321\"},display:{Name:\"§9Guy (NPC)\"},ExtraAttributes:{id:\"GUY_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "GUY_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 52,
+  "y": 80,
+  "z": -13,
+  "island": "hub"
+}

--- a/items/GWENDOLYN_NPC.json
+++ b/items/GWENDOLYN_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Gwendolyn (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"1f2ba922-d99d-29f1-ae2b-2fca0ac9ff70\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzVjMzQzNTE2MDZhOTlmNjJjYWI5ZTdjNTEyODM4NjQ3NTNkMmU2Nzk0OGIxZjEyNmJhZjcwYzEyOTE3MjMzZjAifX19\"}]},Name:\"1f2ba922-d99d-29f1-ae2b-2fca0ac9ff70\"},display:{Name:\"§9Gwendolyn (NPC)\"},ExtraAttributes:{id:\"GWENDOLYN_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "GWENDOLYN_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 89,
+  "y": 199,
+  "z": -98,
+  "island": "mining_3"
+}

--- a/items/HORNUM_NPC.json
+++ b/items/HORNUM_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Hornum (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"f23bca47-7931-2f5a-9f8e-61214625732a\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2ViZjhkZDVjYjkyM2FkM2NhZDU0ODM0MDY2ZThmYTQ2NTlkM2ExODliMTQxMDUxNWU0MDA1YTRlZGUwNTQxZWIifX19\"}]},Name:\"f23bca47-7931-2f5a-9f8e-61214625732a\"},display:{Name:\"§9Hornum (NPC)\"},ExtraAttributes:{id:\"HORNUM_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "HORNUM_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 35,
+  "y": 203,
+  "z": -146,
+  "island": "mining_3"
+}

--- a/items/HUNGRY_HIKER_NPC.json
+++ b/items/HUNGRY_HIKER_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Hungry Hiker (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"3cd268da-3e88-2744-8c7d-8303ca9fa11f\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2Q2ZjliOWI2MjQwNGM1Y2Y5NGMzODVjN2YxYzg2YWRkZTBkOWFlZjlhOWNkMjllMmFiNTgzZmExZGU2M2Y0MjYifX19\"}]},Name:\"3cd268da-3e88-2744-8c7d-8303ca9fa11f\"},display:{Name:\"§9Hungry Hiker (NPC)\"},ExtraAttributes:{id:\"HUNGRY_HIKER_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "HUNGRY_HIKER_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 270,
+  "y": 49,
+  "z": -480,
+  "island": "farming_1"
+}

--- a/items/JACK_NPC.json
+++ b/items/JACK_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Jack (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzgyMmQ4ZTc1MWM4ZjJmZDRjODk0MmM0NGJkYjJmNWNhNGQ4YWU4ZTU3NWVkM2ViMzRjMThhODZlOTNiIn19fQ\u003d\u003d\"}]},Name:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\"},display:{Name:\"§9Jack (NPC)\"},ExtraAttributes:{id:\"JACK_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "JACK_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -1,
+  "y": 71,
+  "z": -55,
+  "island": "hub"
+}

--- a/items/JAMIE_NPC.json
+++ b/items/JAMIE_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Jamie (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzgyMmQ4ZTc1MWM4ZjJmZDRjODk0MmM0NGJkYjJmNWNhNGQ4YWU4ZTU3NWVkM2ViMzRjMThhODZlOTNiIn19fQ\u003d\u003d\"}]},Name:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\"},display:{Name:\"§9Jamie (NPC)\"},ExtraAttributes:{id:\"JAMIE_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "JAMIE_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -36,
+  "y": 69,
+  "z": -39,
+  "island": "hub"
+}

--- a/items/JOTRAELINE_GREATFORGE_NPC.json
+++ b/items/JOTRAELINE_GREATFORGE_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Jotraeline Greatforge (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"df42dfaf-37c8-25bb-ab04-bdebf91f7f5e\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzg1MzYyYjYxZjI5OGRlYzJkZjc2NTQ1N2Q2YjQxN2U5MTdkMjMwOWViYzhmNjkxZjA4NTU0ODk2ODJkZGVjNTkifX19\"}]},Name:\"df42dfaf-37c8-25bb-ab04-bdebf91f7f5e\"},display:{Name:\"§9Jotraeline Greatforge (NPC)\"},ExtraAttributes:{id:\"JOTRAELINE_GREATFORGE_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "JOTRAELINE_GREATFORGE_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -6,
+  "y": 146,
+  "z": -18,
+  "island": "mining_3"
+}

--- a/items/LAZY_MINER_NPC.json
+++ b/items/LAZY_MINER_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Lazy Miner (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"4a887051-ff70-22bb-8bc1-438ae7fc9630\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2Q5M2Q5NjM2YWE5NTU2YWNmNGJlMmNjNThkOTNmZjBiNTMyZTY4MDk4ZjgwYTdkYzE1MWEwZjFkMTZiOGU1ZjgifX19\"}]},Name:\"4a887051-ff70-22bb-8bc1-438ae7fc9630\"},display:{Name:\"§9Lazy Miner (NPC)\"},ExtraAttributes:{id:\"LAZY_MINER_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "LAZY_MINER_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -11,
+  "y": 79,
+  "z": -337,
+  "island": "mining_1"
+}

--- a/items/LEO_NPC.json
+++ b/items/LEO_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Leo (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzgyMmQ4ZTc1MWM4ZjJmZDRjODk0MmM0NGJkYjJmNWNhNGQ4YWU4ZTU3NWVkM2ViMzRjMThhODZlOTNiIn19fQ\u003d\u003d\"}]},Name:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\"},display:{Name:\"§9Leo (NPC)\"},ExtraAttributes:{id:\"LEO_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "LEO_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -8,
+  "y": 71,
+  "z": -76,
+  "island": "hub"
+}

--- a/items/LIAM_NPC.json
+++ b/items/LIAM_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Liam (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzgyMmQ4ZTc1MWM4ZjJmZDRjODk0MmM0NGJkYjJmNWNhNGQ4YWU4ZTU3NWVkM2ViMzRjMThhODZlOTNiIn19fQ\u003d\u003d\"}]},Name:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\"},display:{Name:\"§9Liam (NPC)\"},ExtraAttributes:{id:\"LIAM_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "LIAM_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 10,
+  "y": 71,
+  "z": -42,
+  "island": "hub"
+}

--- a/items/LUMBER_JACK_NPC.json
+++ b/items/LUMBER_JACK_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Lumber Jack (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"6c40e660-c6cb-2412-a81f-a7778fca214c\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzY4MjUwMzBlNzc1MmZhZjdmODE2YWMyYTIwYjExNDMyYWY0YjJjZGU0OTMyZGMwZTkyMDgzMWU2MjE4MDhlZTgifX19\"}]},Name:\"6c40e660-c6cb-2412-a81f-a7778fca214c\"},display:{Name:\"§9Lumber Jack (NPC)\"},ExtraAttributes:{id:\"LUMBER_JACK_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "LUMBER_JACK_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -112,
+  "y": 75,
+  "z": -36,
+  "island": "hub"
+}

--- a/items/LUMINA_NPC.json
+++ b/items/LUMINA_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Lumina (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"22af9295-691f-20d7-8aaa-8e3164d54707\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2NkYTMwOGNhZTE3NzBmNmI3MDliMWYwODAwNGNhMmU5YzIwYWY2ZmY4ZWM1MzgxZDExNGM0NDA2ZGY2YjgwYmMifX19\"}]},Name:\"22af9295-691f-20d7-8aaa-8e3164d54707\"},display:{Name:\"§9Lumina (NPC)\"},ExtraAttributes:{id:\"LUMINA_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "LUMINA_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 78,
+  "y": 200,
+  "z": -110,
+  "island": "mining_3"
+}

--- a/items/LYNN_NPC.json
+++ b/items/LYNN_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Lynn (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzgyMmQ4ZTc1MWM4ZjJmZDRjODk0MmM0NGJkYjJmNWNhNGQ4YWU4ZTU3NWVkM2ViMzRjMThhODZlOTNiIn19fQ\u003d\u003d\"}]},Name:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\"},display:{Name:\"§9Lynn (NPC)\"},ExtraAttributes:{id:\"LYNN_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "LYNN_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -22,
+  "y": 69,
+  "z": -125,
+  "island": "hub"
+}

--- a/items/MADAME_ELEANOR_Q_GOLDSWORTH_IIINPC.json
+++ b/items/MADAME_ELEANOR_Q_GOLDSWORTH_IIINPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Madame Eleanor Q. Goldsworth III(NPC)",
+  "nbttag": "{SkullOwner:{Id:\"ee40f8fc-4790-2dc5-a0b7-4194739c907f\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2I3ZTBmYzhkZjkwNjdkMzkzYzk3N2YxZjM0MDI1NjM0MjIzZGIxNDVlOTQwM2RjMzJjMzExODg5ZTMzNjU5NjUifX19\"}]},Name:\"ee40f8fc-4790-2dc5-a0b7-4194739c907f\"},display:{Name:\"§9Madame Eleanor Q. Goldsworth III(NPC)\"},ExtraAttributes:{id:\"MADAME_ELEANOR_Q_GOLDSWORTH_IIINPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "MADAME_ELEANOR_Q_GOLDSWORTH_IIINPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -49,
+  "y": 78,
+  "z": 77,
+  "island": "hub"
+}

--- a/items/MASON_NPC.json
+++ b/items/MASON_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Mason (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"61f83d41-2248-2326-a3b9-8f0673f90c5c\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzNmY2I0Mjk2Mjg1ZTMzMWE5MzYwMzAwNzJiZTcxNmZjYjRiN2JhM2UzZjU0NDc3OTMyOTRjMDNlZWUxYzkyN2MifX19\"}]},Name:\"61f83d41-2248-2326-a3b9-8f0673f90c5c\"},display:{Name:\"§9Mason (NPC)\"},ExtraAttributes:{id:\"MASON_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "MASON_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 178,
+  "y": 78,
+  "z": -356,
+  "island": "farming_1"
+}

--- a/items/OLD_MAN_GARRY_NPC.json
+++ b/items/OLD_MAN_GARRY_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Old Man Garry (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"c43e8e64-1bf4-2316-8ef2-82fc7bbb32e2\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzkyMTg2N2Y0ZWM3YWZmZjA4OTI2NzFlYWMzOTlhY2RjYzYzMTA1ZDBhZTQ0NjJhNDhhNDNhZjVlY2JhMWU0ZDUifX19\"}]},Name:\"c43e8e64-1bf4-2316-8ef2-82fc7bbb32e2\"},display:{Name:\"§9Old Man Garry (NPC)\"},ExtraAttributes:{id:\"OLD_MAN_GARRY_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "OLD_MAN_GARRY_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 5,
+  "y": 201,
+  "z": -109,
+  "island": "mining_3"
+}

--- a/items/PUZZLER_NPC.json
+++ b/items/PUZZLER_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Puzzler (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"6b17c7cd-0cdc-2484-8a45-13d68fabd567\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzZmNTE0ZDgwMTRkYzZhYTRjODA0ZmZkZjYwOTA5M2Y3ZmYxYTUyODlmMTNjNzE4ODE0MjE4MmRiNDNjODhiM2QifX19\"}]},Name:\"6b17c7cd-0cdc-2484-8a45-13d68fabd567\"},display:{Name:\"§9Puzzler (NPC)\"},ExtraAttributes:{id:\"PUZZLER_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "PUZZLER_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 182,
+  "y": 197,
+  "z": 136,
+  "island": "mining_3"
+}

--- a/items/QUEEN_MISMYLA_NPC.json
+++ b/items/QUEEN_MISMYLA_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Queen Mismyla (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"f92b5adb-57f9-2642-ba0c-17c1ded949f9\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzZmNzAzODVmNDcyYzAzODI1YzBlODk0ZDk0YWMyMDFlMWI2NDJkMTAzMjIwMmQ0YmYzMzM3MmZhM2FhMjlmYmEifX19\"}]},Name:\"f92b5adb-57f9-2642-ba0c-17c1ded949f9\"},display:{Name:\"§9Queen Mismyla (NPC)\"},ExtraAttributes:{id:\"QUEEN_MISMYLA_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "QUEEN_MISMYLA_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 127,
+  "y": 196,
+  "z": 196,
+  "island": "mining_3"
+}

--- a/items/RHYS_NPC.json
+++ b/items/RHYS_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Rhys (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"7dc51aeb-4d77-2e47-a24a-de50bcb9d599\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzZiMjBiMjNjMWFhMmJlMDI3MGYwMTZiNGM5MGQ2ZWU2YjgzMzBhMTdjZmVmODc4NjlkNmFkNjBiMmZmYmYzYjUifX19\"}]},Name:\"7dc51aeb-4d77-2e47-a24a-de50bcb9d599\"},display:{Name:\"§9Rhys (NPC)\"},ExtraAttributes:{id:\"RHYS_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "RHYS_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -38,
+  "y": 201,
+  "z": -119,
+  "island": "mining_3"
+}

--- a/items/ROYAL_RESIDENT_NEIGHBOR_NPC.json
+++ b/items/ROYAL_RESIDENT_NEIGHBOR_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Royal Resident (Neighbor) (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"54fa3d5b-e569-2483-8fa4-397bb3cc9601\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzY1ZjMxYzFjMjE1YTU3ZTkzN2ZkNzVhYjM1NzgyZjg1ZWMyNDJhMWIxZjk1MGEyNmE0MmJiNWUwYWE1Y2JlZGEifX19\"}]},Name:\"54fa3d5b-e569-2483-8fa4-397bb3cc9601\"},display:{Name:\"§9Royal Resident (Neighbor) (NPC)\"},ExtraAttributes:{id:\"ROYAL_RESIDENT_NEIGHBOR_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "ROYAL_RESIDENT_NEIGHBOR_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 165,
+  "y": 203,
+  "z": 279,
+  "island": "mining_3"
+}

--- a/items/ROYAL_RESIDENT_NPC.json
+++ b/items/ROYAL_RESIDENT_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Royal Resident (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"1098c6f2-d527-22a6-9663-47aa924651fa\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2ViZjhkZDVjYjkyM2FkM2NhZDU0ODM0MDY2ZThmYTQ2NTlkM2ExODliMTQxMDUxNWU0MDA1YTRlZGUwNTQxZWIifX19\"}]},Name:\"1098c6f2-d527-22a6-9663-47aa924651fa\"},display:{Name:\"§9Royal Resident (NPC)\"},ExtraAttributes:{id:\"ROYAL_RESIDENT_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "ROYAL_RESIDENT_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 63,
+  "y": 205,
+  "z": 200,
+  "island": "mining_3"
+}

--- a/items/ROYAL_RESIDENT_SNOOTY_NPC.json
+++ b/items/ROYAL_RESIDENT_SNOOTY_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Royal Resident (Snooty) (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"5ac11dcc-d8c9-2e7d-babb-0f22614f4c35\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzI3ZGIxNTQ0MjJjNjQxNTM3MjA0YTA4M2EwMzQwYmJlNWIzYWIwZWI4ODA5ODgzNDA4ZDJhNzhkZTFlNTkyYSJ9fX0\u003d\"}]},Name:\"5ac11dcc-d8c9-2e7d-babb-0f22614f4c35\"},display:{Name:\"§9Royal Resident (Snooty) (NPC)\"},ExtraAttributes:{id:\"ROYAL_RESIDENT_SNOOTY_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "ROYAL_RESIDENT_SNOOTY_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 92,
+  "y": 203,
+  "z": 277,
+  "island": "mining_3"
+}

--- a/items/RUSTY_NPC.json
+++ b/items/RUSTY_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Rusty (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzgyMmQ4ZTc1MWM4ZjJmZDRjODk0MmM0NGJkYjJmNWNhNGQ4YWU4ZTU3NWVkM2ViMzRjMThhODZlOTNiIn19fQ\u003d\u003d\"}]},Name:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\"},display:{Name:\"§9Rusty (NPC)\"},ExtraAttributes:{id:\"RUSTY_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "RUSTY_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -20,
+  "y": 79,
+  "z": -326,
+  "island": "mining_1"
+}

--- a/items/RYU_NPC.json
+++ b/items/RYU_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Ryu (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzgyMmQ4ZTc1MWM4ZjJmZDRjODk0MmM0NGJkYjJmNWNhNGQ4YWU4ZTU3NWVkM2ViMzRjMThhODZlOTNiIn19fQ\u003d\u003d\"}]},Name:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\"},display:{Name:\"§9Ryu (NPC)\"},ExtraAttributes:{id:\"RYU_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "RYU_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 28,
+  "y": 71,
+  "z": -116,
+  "island": "hub"
+}

--- a/items/SARGWYN_NPC.json
+++ b/items/SARGWYN_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Sargwyn (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"2a57f553-cf00-24a9-a963-ad8fdc095feb\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzY1ZjMxYzFjMjE1YTU3ZTkzN2ZkNzVhYjM1NzgyZjg1ZWMyNDJhMWIxZjk1MGEyNmE0MmJiNWUwYWE1Y2JlZGEifX19\"}]},Name:\"2a57f553-cf00-24a9-a963-ad8fdc095feb\"},display:{Name:\"§9Sargwyn (NPC)\"},ExtraAttributes:{id:\"SARGWYN_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "SARGWYN_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 35,
+  "y": 203,
+  "z": -150,
+  "island": "mining_3"
+}

--- a/items/SHAGGY_NPC.json
+++ b/items/SHAGGY_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Shaggy (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"05ad317c-98c8-2cb9-b56f-31a0b0db66b6\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzI1OGY4OGRjYmQyYWYxMTBjNzdjZmZhYTAwZWFiN2E0OTljMDAxMzNlNjE1NzU1OTlkOWUwNmU2MWI4YTI0YTYifX19\"}]},Name:\"05ad317c-98c8-2cb9-b56f-31a0b0db66b6\"},display:{Name:\"§9Shaggy (NPC)\"},ExtraAttributes:{id:\"SHAGGY_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "SHAGGY_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -278,
+  "y": 122,
+  "z": -182,
+  "island": "combat_1"
+}

--- a/items/STELLA_NPC.json
+++ b/items/STELLA_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Stella (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzgyMmQ4ZTc1MWM4ZjJmZDRjODk0MmM0NGJkYjJmNWNhNGQ4YWU4ZTU3NWVkM2ViMzRjMThhODZlOTNiIn19fQ\u003d\u003d\"}]},Name:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\"},display:{Name:\"§9Stella (NPC)\"},ExtraAttributes:{id:\"STELLA_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "STELLA_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 17,
+  "y": 71,
+  "z": -100,
+  "island": "hub"
+}

--- a/items/TAMMY_NPC.json
+++ b/items/TAMMY_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Tammy (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"af776b0d-7032-2856-a887-3d3cc4733e98\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2NlZGM2ZTc3MmQ1MGU2MzU1NmJmZGU5MTRlNzg1Yzc1NDg5MzYxZmNjNzk4NTE2NGM0MGIzMDBlN2Y5MWJjMDgifX19\"}]},Name:\"af776b0d-7032-2856-a887-3d3cc4733e98\"},display:{Name:\"§9Tammy (NPC)\"},ExtraAttributes:{id:\"TAMMY_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "TAMMY_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 285,
+  "y": 105,
+  "z": -544,
+  "island": "farming_1"
+}

--- a/items/TARWEN_NPC.json
+++ b/items/TARWEN_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Tarwen (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"d002e39d-d54c-203b-abaa-ac98d44adbb5\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzIxM2NmMGNhNzlhMzYxMWI4ZTA1ZmU5ZTI2NGZiMmJmOGQyN2U0NjRkYzEyZGM2ZTk1ZGQwYWUwYzMzNWE1NjEifX19\"}]},Name:\"d002e39d-d54c-203b-abaa-ac98d44adbb5\"},display:{Name:\"§9Tarwen (NPC)\"},ExtraAttributes:{id:\"TARWEN_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "TARWEN_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 34,
+  "y": 203,
+  "z": -141,
+  "island": "mining_3"
+}

--- a/items/TIA_THE_FAIRY_NPC.json
+++ b/items/TIA_THE_FAIRY_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Tia the Fairy (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"fc250541-e5de-27ce-9f91-a8a3e704e594\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2RmYTExYjMwM2NiYTFhZTIzNTFiMWU5NWQzYzliZmI5MDA4NzA3NWFkMjlkODE3ZGVlNjI3M2RjN2E4OTZkYjIifX19\"}]},Name:\"fc250541-e5de-27ce-9f91-a8a3e704e594\"},display:{Name:\"§9Tia the Fairy (NPC)\"},ExtraAttributes:{id:\"TIA_THE_FAIRY_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "TIA_THE_FAIRY_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 130,
+  "y": 67,
+  "z": 138,
+  "island": "hub"
+}

--- a/items/TOM_NPC.json
+++ b/items/TOM_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Tom (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzgyMmQ4ZTc1MWM4ZjJmZDRjODk0MmM0NGJkYjJmNWNhNGQ4YWU4ZTU3NWVkM2ViMzRjMThhODZlOTNiIn19fQ\u003d\u003d\"}]},Name:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\"},display:{Name:\"§9Tom (NPC)\"},ExtraAttributes:{id:\"TOM_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "TOM_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 28,
+  "y": 70,
+  "z": -58,
+  "island": "hub"
+}

--- a/items/TREVOR_NPC.json
+++ b/items/TREVOR_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Trevor (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"a862dcb2-8c40-27c9-8bcd-7e6a5a320f0e\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzYxMDJmODIxNDg0NjFjZWQxZjdiNjJlMzI2ZWIyZGIzYTk0YTMzY2JhODFkNDI4MTQ1MmFmNGQ4YWVjYTQ5OTEifX19\"}]},Name:\"a862dcb2-8c40-27c9-8bcd-7e6a5a320f0e\"},display:{Name:\"§9Trevor (NPC)\"},ExtraAttributes:{id:\"TREVOR_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "TREVOR_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 282,
+  "y": 105,
+  "z": -542,
+  "island": "farming_1"
+}

--- a/items/VEX_NPC.json
+++ b/items/VEX_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Vex (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzgyMmQ4ZTc1MWM4ZjJmZDRjODk0MmM0NGJkYjJmNWNhNGQ4YWU4ZTU3NWVkM2ViMzRjMThhODZlOTNiIn19fQ\u003d\u003d\"}]},Name:\"c9540683-51e4-3942-ad17-4f2c3f3ae4b7\"},display:{Name:\"§9Vex (NPC)\"},ExtraAttributes:{id:\"VEX_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "VEX_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": -17,
+  "y": 71,
+  "z": -82,
+  "island": "hub"
+}

--- a/items/WIZARD_NPC.json
+++ b/items/WIZARD_NPC.json
@@ -1,0 +1,14 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Wizard (NPC)",
+  "nbttag": "{SkullOwner:{Id:\"6fe4aaad-6875-28e5-b737-f118d47e452c\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHBzOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzJmNjlhYjJmNGU3MzQxYWMyNjI1OTcwODNjYTM4YWQwMWJmYmJmODczMGZiZmJkZDEwY2E5MGFlZTMzN2EyZGQifX19\"}]},Name:\"6fe4aaad-6875-28e5-b737-f118d47e452c\"},display:{Name:\"§9Wizard (NPC)\"},ExtraAttributes:{id:\"WIZARD_NPC\"}}",
+  "damage": 3,
+  "lore": [],
+  "internalname": "WIZARD_NPC",
+  "clickcommand": "",
+  "modver": "2.1.1-PRE",
+  "x": 47,
+  "y": 123,
+  "z": 76,
+  "island": "hub"
+}


### PR DESCRIPTION
Adds waypoints to most garden NPCs. Missing are: Sirius (because i dont wanna wait for a dark auction), Terry (because uhhhhh island closed), and all the crystal hollow NPCs. This took a total of 35 minutes, jani you are a pussy telling me this would be effort.