### PR TITLE
Small fix to lapis pickaxe

### DIFF
--- a/items/LAPIS_PICKAXE.json
+++ b/items/LAPIS_PICKAXE.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:diamond_pickaxe",
   "displayname": "§aLapis Pickaxe",
-  "nbttag": "{Unbreakable:1b,HideFlags:254,display:{Lore:[0:\"§8Breaking Power 4\",1:\"\",2:\"§7Damage: §c+20\",3:\"§7Mining Speed: §a+200\",4:\"\",5:\"§7§7Grants a §a25% §7chance to\",6:\"§7gain double experience when\",7:\"§7mining ores.\",8:\"\",9:\"§6Ability: Mining Speed Boost  §e§lRIGHT CLICK\",10:\"§7Grants §a+§a300% §6⸕ Mining\",11:\"§6Speed §7for §a20s§7.\",12:\"§8Cooldown: §a120s\",13:\"\",14:\"§7§8This item can be reforged!\",15:\"§a§lUNCOMMON PICKAXE\"],Name:\"§aLapis Pickaxe\"},ExtraAttributes:{id:\"LAPIS_PICKAXE\"}}",
+  "nbttag": "{Unbreakable:1b,HideFlags:254,display:{Lore:[0:\"§8Breaking Power 4\",1:\"\",2:\"§7Damage: §c+20\",3:\"§7Mining Speed: §a+200\",4:\"\",5:\"§7§7Grants a §a25% §7chance to\",6:\"§7gain double experience when\",7:\"§7mining ores.\",8:\"\",9:\"§7§8This item can be reforged!\",10:\"§a§lUNCOMMON PICKAXE\"],Name:\"§aLapis Pickaxe\"},ExtraAttributes:{id:\"LAPIS_PICKAXE\"}}",
   "damage": 0,
   "lore": [
     "§8Breaking Power 4",
@@ -12,11 +12,6 @@
     "§7§7Grants a §a25% §7chance to",
     "§7gain double experience when",
     "§7mining ores.",
-    "",
-    "§6Ability: Mining Speed Boost  §e§lRIGHT CLICK",
-    "§7Grants §a+§a300% §6⸕ Mining",
-    "§6Speed §7for §a20s§7.",
-    "§8Cooldown: §a120s",
     "",
     "§7§8This item can be reforged!",
     "§a§lUNCOMMON PICKAXE"


### PR DESCRIPTION
Removed the description of Mining Speed Boost from the Lapis Pickaxe, to be consistent with all other mining tools.

See you in 6 months.