### PR TITLE
Remove Duplicate Recipe for Self-Recursive Pickaxe

### DIFF
--- a/items/SELF_RECURSIVE_PICKAXE.json
+++ b/items/SELF_RECURSIVE_PICKAXE.json
@@ -15,17 +15,6 @@
     "",
     "§9§lRARE SWORD"
   ],
-  "recipe": {
-    "A1": "NULLIFIED_METAL:2",
-    "A2": "NULLIFIED_METAL:2",
-    "A3": "NULLIFIED_METAL:2",
-    "B1": "",
-    "B2": "WILTED_BERBERIS:24",
-    "B3": "",
-    "C1": "",
-    "C2": "TACTICIAN_MURDER_WEAPON:1",
-    "C3": ""
-  },
   "internalname": "SELF_RECURSIVE_PICKAXE",
   "clickcommand": "viewrecipe",
   "modver": "2.1.1-PRE",


### PR DESCRIPTION
Currently, viewing the Self-Recursive Pickaxe results in 3 recipes, though two are identical. 

It seems like this is the only item in-game to have multiple distinct recipes where different items are used (or at least I couldn't find another in a quick search). 

Quickly testing, it worked in-game both removing the "recipe" and having both in "recipes" as well as removing one in "recipes" and also having "recipe". 

If this is setup this way on purpose and this duplicate is just a necessary side-effect, please let me know. 