### PR TITLE
Fix fear mongerer price of intimidation artifact

### DIFF
--- a/items/FEAR_MONGERER_NPC.json
+++ b/items/FEAR_MONGERER_NPC.json
@@ -142,7 +142,7 @@
       "type": "npc_shop",
       "cost": [
         "INTIMIDATION_RING:1",
-        "PURPLE_CANDY:64"
+        "PURPLE_CANDY:100"
       ],
       "result": "INTIMIDATION_ARTIFACT"
     },


### PR DESCRIPTION
Previous file said it takes 64 purple candy + the ring to get the intimidation artifact, but it's actually 100,