### PR TITLE
Reforgestones cleanup

### DIFF
--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -304,8 +304,8 @@
       "LEGENDARY": 10000
     },
     "reforgeAbility": {
-      "EPIC": "Grants §a+1 §5Fear.",
-      "LEGENDARY": "Grants §a+1 §5Fear."
+      "EPIC": "Grants §a+1 §5Fear§f.",
+      "LEGENDARY": "Grants §a+1 §5Fear§f."
     },
     "reforgeStats": {
        "EPIC": {
@@ -313,7 +313,7 @@
       "LEGENDARY": {
       }
     }
-  }
+  },
   "CANDY_CORN": {
     "internalName": "CANDY_CORN",
     "reforgeName": "Candied",

--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -290,6 +290,24 @@
       }
     }
   },
+  "BOO_STONE": {
+    "internalName": "BOO_STONE",
+    "reforgeName": "Greater Spook",
+    "reforgeType": "blacksmith/reforge_stone",
+    "itemTypes": "ARMOR",
+    "requiredRarities": [
+      "EPIC",
+      "LEGENDARY"
+    ],
+    "reforgeCosts": {
+      "EPIC": 10000,
+      "LEGENDARY": 10000
+    },
+    "reforgeAbility": {
+      "EPIC": "Grants §a+1 §5Fear.",
+      "LEGENDARY": "Grants §a+1 §5Fear."
+    }
+  }
   "CANDY_CORN": {
     "internalName": "CANDY_CORN",
     "reforgeName": "Candied",

--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -2076,7 +2076,7 @@
       "MYTHIC": 300000,
       "DIVINE": 400000
     },
-    "reforgeAbility": "Heal 1.15x more from Vampirism and Lifesteal.",
+    "reforgeAbility": "Heal §a1.15x§f more from §9Vampirism§f and §9Lifesteal.",
     "reforgeStats": {
       "COMMON": {
         "health": 6,

--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -303,13 +303,7 @@
       "EPIC": 10000,
       "LEGENDARY": 10000
     },
-    "reforgeAbility": "Grants §a+1 §5Fear§7.",
-    "reforgeStats": {
-       "EPIC": {
-       },
-      "LEGENDARY": {
-      }
-    }
+    "reforgeAbility": "Grants §a+1 §5Fear§7."
   },
   "CANDY_CORN": {
     "internalName": "CANDY_CORN",

--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -1357,7 +1357,7 @@
       "LEGENDARY": 300000,
       "MYTHIC": 600000
     },
-    "reforgeAbility": "§7Decreases the health of Lava Sea Creatures by 1% for each unique Lava Sea Creature you have killed with this rod in your inventory.",
+    "reforgeAbility": "§7Decreases the health of Lava Sea Creatures by §c1%§f for each unique Lava Sea Creature you have killed with this rod in your inventory.",
     "reforgeStats": {
       "COMMON": {
         "strength": 5,

--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -304,8 +304,8 @@
       "LEGENDARY": 10000
     },
     "reforgeAbility": {
-      "EPIC": "Grants §a+1 §5Fear§f.",
-      "LEGENDARY": "Grants §a+1 §5Fear§f."
+      "EPIC": "Grants §a+1 §5Fear§7.",
+      "LEGENDARY": "Grants §a+1 §5Fear§7."
     },
     "reforgeStats": {
        "EPIC": {
@@ -1056,7 +1056,7 @@
       "LEGENDARY": 100000,
       "MYTHIC": 250000
     },
-    "reforgeAbility": "Every §c7th§f melee hit on an enemy deals §c+100%§f damage.",
+    "reforgeAbility": "Every §c7th§7 melee hit on an enemy deals §c+100%§7 damage.",
     "reforgeStats": {
       "COMMON": {
         "strength": 30,
@@ -1357,7 +1357,7 @@
       "LEGENDARY": 300000,
       "MYTHIC": 600000
     },
-    "reforgeAbility": "§7Decreases the health of Lava Sea Creatures by §c1%§f for each unique Lava Sea Creature you have killed with this rod in your inventory.",
+    "reforgeAbility": "§7Decreases the health of Lava Sea Creatures by §c1%§7 for each unique Lava Sea Creature you have killed with this rod in your inventory.",
     "reforgeStats": {
       "COMMON": {
         "strength": 5,
@@ -2100,7 +2100,7 @@
       "MYTHIC": 300000,
       "DIVINE": 400000
     },
-    "reforgeAbility": "Heal §a1.15x§f more from §9Vampirism§f and §9Lifesteal.",
+    "reforgeAbility": "Heal §a1.15x§7 more from §9Vampirism§7 and §9Lifesteal.",
     "reforgeStats": {
       "COMMON": {
         "health": 6,

--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -303,10 +303,7 @@
       "EPIC": 10000,
       "LEGENDARY": 10000
     },
-    "reforgeAbility": {
-      "EPIC": "Grants §a+1 §5Fear§7.",
-      "LEGENDARY": "Grants §a+1 §5Fear§7."
-    },
+    "reforgeAbility": "Grants §a+1 §5Fear§7.",
     "reforgeStats": {
        "EPIC": {
        },

--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -309,7 +309,7 @@
     },
     "reforgeStats": {
        "EPIC": {
-       }
+       },
       "LEGENDARY": {
       }
     }

--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -306,6 +306,12 @@
     "reforgeAbility": {
       "EPIC": "Grants §a+1 §5Fear.",
       "LEGENDARY": "Grants §a+1 §5Fear."
+    },
+    "reforgeStats": {
+       "EPIC": {
+       }
+      "LEGENDARY": {
+      }
     }
   }
   "CANDY_CORN": {

--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -1468,48 +1468,6 @@
       }
     }
   },
-  "LUXURIOUS_SPOOL": {
-    "internalName": "LUXURIOUS_SPOOL",
-    "reforgeName": "Silky",
-    "reforgeType": "blacksmith/reforge_stone",
-    "itemTypes": "ACCESSORY",
-    "requiredRarities": [
-      "COMMON",
-      "UNCOMMON",
-      "RARE",
-      "EPIC",
-      "LEGENDARY",
-      "MYTHIC"
-    ],
-    "reforgeCosts": {
-      "COMMON": 250,
-      "UNCOMMON": 500,
-      "RARE": 1000,
-      "EPIC": 2500,
-      "LEGENDARY": 5000,
-      "MYTHIC": 10000
-    },
-    "reforgeStats": {
-      "COMMON": {
-        "crit_damage": 5
-      },
-      "UNCOMMON": {
-        "crit_damage": 6
-      },
-      "RARE": {
-        "crit_damage": 8
-      },
-      "EPIC": {
-        "crit_damage": 10
-      },
-      "LEGENDARY": {
-        "crit_damage": 15
-      },
-      "MYTHIC": {
-        "crit_damage": 20
-      }
-    }
-  },
   "LUCKY_DICE": {
     "internalName": "LUCKY_DICE",
     "reforgeName": "Lucky",

--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -1056,7 +1056,7 @@
       "LEGENDARY": 100000,
       "MYTHIC": 250000
     },
-    "reforgeAbility": "Every 7th melee hit on an enemy deals +100% damage.",
+    "reforgeAbility": "Every §c7th§f melee hit on an enemy deals §c+100%§f damage.",
     "reforgeStats": {
       "COMMON": {
         "strength": 30,

--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -2100,7 +2100,7 @@
     "internalName": "PRESUMED_GALLON_OF_RED_PAINT",
     "reforgeName": "Blood-Soaked",
     "reforgeType": "blacksmith/reforge_stone",
-    "itemTypes": "EQUIPMENT",
+    "itemTypes": "CLOAK",
     "requiredRarities": [
       "COMMON",
       "UNCOMMON",


### PR DESCRIPTION
mostly formatting fixes for the reforgeAbility.
Removed Luxurious Spool, since this item does not exit anymore.
Added Boo Stone.
Changed ItemType of Presumend Gallon of Red Paint to Cloak