### PR TITLE
Fixed wrong drop internal name of Plhlegblast

### DIFF
--- a/items/PLHLEGBLAST_SC.json
+++ b/items/PLHLEGBLAST_SC.json
@@ -49,7 +49,7 @@
           "chance": "100%"
         },
         {
-          "id": "ENCHANTED_LILY_PAD",
+          "id": "ENCHANTED_WATER_LILY",
           "extra": [
             "x1-2"
           ],


### PR DESCRIPTION
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/assets/24389977/1b45fb0f-e744-4250-98ce-e703d3578fbc)

![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/assets/24389977/a65511c1-09a8-4088-b4e2-f91d043612dc)