### PR TITLE
ReforgeStones: added advanced itemTypes

### DIFF
--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -1051,7 +1051,7 @@
     "reforgeName": "Fanged",
     "reforgeType": "blacksmith/reforge_stone",
     "itemTypes": {
-      "itemid": [
+      "itemId": [
         "minecraft:iron_sword"
       ]
     },

--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -1039,7 +1039,11 @@
     "internalName": "FULL_JAW_FANGING_KIT",
     "reforgeName": "Fanged",
     "reforgeType": "blacksmith/reforge_stone",
-    "itemTypes": "SWORD",
+    "itemTypes": {
+      "itemid" : [
+        "minecraft:iron_sword"
+      ]
+    },
     "requiredRarities": [
       "COMMON",
       "UNCOMMON",

--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -294,7 +294,18 @@
     "internalName": "BOO_STONE",
     "reforgeName": "Greater Spook",
     "reforgeType": "blacksmith/reforge_stone",
-    "itemTypes": "ARMOR",
+    "itemTypes": {
+      "internalName": [
+        "GREAT_SPOOK_HELMET",
+        "GREAT_SPOOK_CHESTPLATE",
+        "GREAT_SPOOK_LEGGINGS",
+        "GREAT_SPOOK_BOOTS",
+        "GREAT_SPOOK_BELT",
+        "GREAT_SPOOK_CLOAK",
+        "GREAT_SPOOK_NECKLACE",
+        "GREAT_SPOOK_GLOVES"
+      ]
+    },
     "requiredRarities": [
       "EPIC",
       "LEGENDARY"
@@ -874,7 +885,7 @@
     "reforgeName": "Coldfused",
     "reforgeType": "blacksmith/reforge_stone",
     "itemTypes": {
-      "internalName" : [
+      "internalName": [
         "FIREDUST_DAGGER",
         "KINDLEBANE_DAGGER",
         "MAWDREDGE_DAGGER",
@@ -1040,7 +1051,7 @@
     "reforgeName": "Fanged",
     "reforgeType": "blacksmith/reforge_stone",
     "itemTypes": {
-      "itemid" : [
+      "itemid": [
         "minecraft:iron_sword"
       ]
     },
@@ -1263,7 +1274,12 @@
     "internalName": "JERRY_STONE",
     "reforgeName": "Jerry's",
     "reforgeType": "blacksmith/reforge_stone",
-    "itemTypes": "SWORD",
+    "itemTypes": {
+      "internalName" : [
+        "ASPECT_OF_THE_JERRY",
+        "ASPECT_OF_THE_JERRY_SIGNATURE"
+      ]
+    },
     "requiredRarities": [
       "COMMON",
       "UNCOMMON",
@@ -1548,7 +1564,12 @@
     "internalName": "MIDAS_JEWEL",
     "reforgeName": "Gilded",
     "reforgeType": "blacksmith/reforge_stone",
-    "itemTypes": "SWORD",
+    "itemTypes": {
+      "internalName": [
+        "MIDAS\u0027_SWORD",
+        "MIDAS_STAFF"
+      ]
+    },
     "requiredRarities": [
       "LEGENDARY",
       "MYTHIC"
@@ -3008,7 +3029,12 @@
     "internalName": "AOTE_STONE",
     "reforgeName": "Warped",
     "reforgeType": "blacksmith/reforge_stone",
-    "itemTypes": "SWORD",
+    "itemTypes": {
+      "internalName" : [
+        "ASPECT_OF_THE_END",
+        "ASPECT_OF_THE_VOID"
+      ]
+    },
     "requiredRarities": [
       "RARE",
       "EPIC",

--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -873,7 +873,16 @@
     "internalName": "ENTROPY_SUPPRESSOR",
     "reforgeName": "Coldfused",
     "reforgeType": "blacksmith/reforge_stone",
-    "itemTypes": "SWORD",
+    "itemTypes": {
+      "internalName" : [
+        "FIREDUST_DAGGER",
+        "KINDLEBANE_DAGGER",
+        "MAWDREDGE_DAGGER",
+        "PYROCHAOS_DAGGER",
+        "TWILIGHT_DAGGER",
+        "DEATHRIPPER_DAGGER"
+      ]
+    },
     "requiredRarities": [
       "COMMON",
       "UNCOMMON",


### PR DESCRIPTION
since I was made aware that the itemTypes isn't used in neu, I thought to change it to represent to correct type.
Since some reforgestones can only be applied to specific items, therefore a list of internal names for accepted items. But since hypixel is funny there is also a need to specify the itemid since FULL-JAW-FANGED-KID is applicable to only iron swords.
Eg. Gilded -> midas staff & midas sword.