### PR TITLE
Added new constant reforges

### DIFF
--- a/constants/reforges.json
+++ b/constants/reforges.json
@@ -1,7 +1,15 @@
 {
   "Astute": {
     "reforgeName": "Astute",
-    "itemType": "EQUIPMENT",
+    "itemTypes": "EQUIPMENT",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "health": 1.0,
@@ -37,7 +45,15 @@
   },
   "Awkward": {
     "reforgeName": "Awkward",
-    "itemType": "BOW",
+    "itemTypes": "BOW",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "intelligence": -5.0,
@@ -73,7 +89,15 @@
   },
   "Blended": {
     "reforgeName": "Blended",
-    "itemType": "EQUIPMENT",
+    "itemTypes": "EQUIPMENT",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "health": 1.0,
@@ -139,7 +163,15 @@
   },
   "Brilliant": {
     "reforgeName": "Brilliant",
-    "itemType": "EQUIPMENT",
+    "itemTypes": "EQUIPMENT",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "health": 1.0,
@@ -175,7 +207,15 @@
   },
   "Clean": {
     "reforgeName": "Clean",
-    "itemType": "ARMOR",
+    "itemTypes": "ARMOR",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "health": 5.0,
@@ -211,7 +251,15 @@
   },
   "Colossal": {
     "reforgeName": "Colossal",
-    "itemType": "EQUIPMENT",
+    "itemTypes": "EQUIPMENT",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "health": 3.0,
@@ -241,7 +289,15 @@
   },
   "Deadly": {
     "reforgeName": "Deadly",
-    "itemType": "BOW",
+    "itemTypes": "BOW",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "crit_damage": 5.0,
@@ -271,7 +327,15 @@
   },
   "Double-Bit": {
     "reforgeName": "Double-Bit",
-    "itemType": "AXE",
+    "itemTypes": "AXE",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "speed": 1.0,
@@ -301,7 +365,15 @@
   },
   "Epic": {
     "reforgeName": "Epic",
-    "itemType": "SWORD/ROD",
+    "itemTypes": "SWORD/ROD",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "strength": 15.0,
@@ -337,7 +409,15 @@
   },
   "Excellent": {
     "reforgeName": "Excellent",
-    "itemType": "PICKAXE",
+    "itemTypes": "PICKAXE",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "speed": 1.0,
@@ -367,7 +447,15 @@
   },
   "Fair": {
     "reforgeName": "Fair",
-    "itemType": "SWORD/ROD",
+    "itemTypes": "SWORD/ROD",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "strength": 2.0,
@@ -415,7 +503,15 @@
   },
   "Fast": {
     "reforgeName": "Fast",
-    "itemType": "SWORD/ROD",
+    "itemTypes": "SWORD/ROD",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "bonus_attack_speed": 10.0
@@ -439,7 +535,15 @@
   },
   "Fierce": {
     "reforgeName": "Fierce",
-    "itemType": "ARMOR",
+    "itemTypes": "ARMOR",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "strength": 2.0,
@@ -475,7 +579,15 @@
   },
   "Fine": {
     "reforgeName": "Fine",
-    "itemType": "BOW",
+    "itemTypes": "BOW",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "strength": 3.0,
@@ -511,7 +623,15 @@
   },
   "Fortunate": {
     "reforgeName": "Fortunate",
-    "itemType": "PICKAXE",
+    "itemTypes": "PICKAXE",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "mining_speed": 1.0,
@@ -541,7 +661,15 @@
   },
   "Gentle": {
     "reforgeName": "Gentle",
-    "itemType": "SWORD/ROD",
+    "itemTypes": "SWORD/ROD",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "strength": 3.0,
@@ -571,7 +699,15 @@
   },
   "Grand": {
     "reforgeName": "Grand",
-    "itemType": "BOW",
+    "itemTypes": "BOW",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "strength": 25.0
@@ -595,7 +731,15 @@
   },
   "Great": {
     "reforgeName": "Great",
-    "itemType": "AXE",
+    "itemTypes": "AXE",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "strength": 2.0,
@@ -631,7 +775,15 @@
   },
   "Green Thumb": {
     "reforgeName": "Green Thumb",
-    "itemType": "HOE",
+    "itemTypes": "HOE",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "speed": 1.0,
@@ -661,7 +813,15 @@
   },
   "Hasty": {
     "reforgeName": "Hasty",
-    "itemType": "BOW",
+    "itemTypes": "BOW",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "strength": 3.0,
@@ -691,7 +851,15 @@
   },
   "Heavy": {
     "reforgeName": "Heavy",
-    "itemType": "ARMOR",
+    "itemTypes": "ARMOR",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "defense": 25.0,
@@ -727,7 +895,15 @@
   },
   "Hefty": {
     "reforgeName": "Hefty",
-    "itemType": "EQUIPMENT",
+    "itemTypes": "EQUIPMENT",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "defense": 7.0,
@@ -763,7 +939,15 @@
   },
   "Heroic": {
     "reforgeName": "Heroic",
-    "itemType": "SWORD/ROD",
+    "itemTypes": "SWORD/ROD",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "strength": 15.0,
@@ -799,7 +983,15 @@
   },
   "Honored": {
     "reforgeName": "Honored",
-    "itemType": "EQUIPMENT",
+    "itemTypes": "EQUIPMENT",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "health": 1.0,
@@ -853,7 +1045,15 @@
   },
   "Legendary": {
     "reforgeName": "Legendary",
-    "itemType": "SWORD/ROD",
+    "itemTypes": "SWORD/ROD",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "strength": 3.0,
@@ -901,7 +1101,15 @@
   },
   "Light": {
     "reforgeName": "Light",
-    "itemType": "ARMOR",
+    "itemTypes": "ARMOR",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "health": 5.0,
@@ -955,7 +1163,15 @@
   },
   "Lumberjack\u0027s": {
     "reforgeName": "Lumberjack\u0027s",
-    "itemType": "AXE",
+    "itemTypes": "AXE",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "speed": 1.0,
@@ -985,7 +1201,15 @@
   },
   "Lush": {
     "reforgeName": "Lush",
-    "itemType": "AXE",
+    "itemTypes": "AXE",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "speed": 3.0,
@@ -1015,7 +1239,15 @@
   },
   "Menacing": {
     "reforgeName": "Menacing",
-    "itemType": "EQUIPMENT",
+    "itemTypes": "EQUIPMENT",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "crit_damage": 2.0,
@@ -1045,7 +1277,15 @@
   },
   "Mythic": {
     "reforgeName": "Mythic",
-    "itemType": "ARMOR",
+    "itemTypes": "ARMOR",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "health": 2.0,
@@ -1099,7 +1339,15 @@
   },
   "Neat": {
     "reforgeName": "Neat",
-    "itemType": "BOW",
+    "itemTypes": "BOW",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "intelligence": 3.0,
@@ -1135,7 +1383,15 @@
   },
   "Odd": {
     "reforgeName": "Odd",
-    "itemType": "SWORD/ROD",
+    "itemTypes": "SWORD/ROD",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "intelligence": -5.0,
@@ -1171,7 +1427,15 @@
   },
   "Peasant\u0027s": {
     "reforgeName": "Peasant\u0027s",
-    "itemType": "HOE",
+    "itemTypes": "HOE",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "speed": 1.0,
@@ -1201,7 +1465,15 @@
   },
   "Prospector\u0027s": {
     "reforgeName": "Prospector\u0027s",
-    "itemType": "PICKAXE",
+    "itemTypes": "PICKAXE",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "speed": 1.0,
@@ -1231,7 +1503,15 @@
   },
   "Pure": {
     "reforgeName": "Pure",
-    "itemType": "ARMOR",
+    "itemTypes": "ARMOR",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "health": 2.0,
@@ -1297,7 +1577,15 @@
   },
   "Rapid": {
     "reforgeName": "Rapid",
-    "itemType": "BOW",
+    "itemTypes": "BOW",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "strength": 2.0,
@@ -1327,7 +1615,15 @@
   },
   "Rich": {
     "reforgeName": "Rich",
-    "itemType": "BOW",
+    "itemTypes": "BOW",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "intelligence": 3.0,
@@ -1363,7 +1659,15 @@
   },
   "Robust": {
     "reforgeName": "Robust",
-    "itemType": "HOE",
+    "itemTypes": "HOE",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "farming_fortune": 2.0
@@ -1387,7 +1691,15 @@
   },
   "Rugged": {
     "reforgeName": "Rugged",
-    "itemType": "AXE",
+    "itemTypes": "AXE",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "strength": 4.0,
@@ -1417,7 +1729,15 @@
   },
   "Sharp": {
     "reforgeName": "Sharp",
-    "itemType": "SWORD/ROD",
+    "itemTypes": "SWORD/ROD",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "crit_damage": 20.0,
@@ -1447,7 +1767,15 @@
   },
   "Smart": {
     "reforgeName": "Smart",
-    "itemType": "ARMOR",
+    "itemTypes": "ARMOR",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "health": 4.0,
@@ -1483,7 +1811,15 @@
   },
   "Soft": {
     "reforgeName": "Soft",
-    "itemType": "EQUIPMENT",
+    "itemTypes": "EQUIPMENT",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "health": 2.0,
@@ -1537,7 +1873,15 @@
   },
   "Spicy": {
     "reforgeName": "Spicy",
-    "itemType": "SWORD/ROD",
+    "itemTypes": "SWORD/ROD",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "strength": 2.0,
@@ -1579,7 +1923,15 @@
   },
   "Stained": {
     "reforgeName": "Stained",
-    "itemType": "EQUIPMENT",
+    "itemTypes": "EQUIPMENT",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "health": 2.0,
@@ -1615,7 +1967,15 @@
   },
   "Sturdy": {
     "reforgeName": "Sturdy",
-    "itemType": "PICKAXE",
+    "itemTypes": "PICKAXE",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "defense": 3.0,
@@ -1645,7 +2005,15 @@
   },
   "Titanic": {
     "reforgeName": "Titanic",
-    "itemType": "ARMOR",
+    "itemTypes": "ARMOR",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "health": 10.0,
@@ -1675,7 +2043,15 @@
   },
   "Unreal": {
     "reforgeName": "Unreal",
-    "itemType": "BOW",
+    "itemTypes": "BOW",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "strength": 3.0,
@@ -1711,7 +2087,15 @@
   },
   "Unyielding": {
     "reforgeName": "Unyielding",
-    "itemType": "PICKAXE",
+    "itemTypes": "PICKAXE",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "speed": 1.0,
@@ -1741,7 +2125,15 @@
   },
   "Wise": {
     "reforgeName": "Wise",
-    "itemType": "ARMOR",
+    "itemTypes": "ARMOR",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "health": 6.0,
@@ -1777,7 +2169,15 @@
   },
   "Zooming": {
     "reforgeName": "Zooming",
-    "itemType": "HOE",
+    "itemTypes": "HOE",
+    "requiredRarities": [
+      "COMMON",
+      "UNCOMMON",
+      "RARE",
+      "EPIC",
+      "LEGENDARY",
+      "MYTHIC"
+    ],
     "reforgeStats": {
       "COMMON": {
         "speed": 5.0

--- a/constants/reforges.json
+++ b/constants/reforges.json
@@ -1,0 +1,1802 @@
+{
+  "Astute": {
+    "reforgeName": "Astute",
+    "itemType": "EQUIPMENT",
+    "reforgeStats": {
+      "COMMON": {
+        "health": 1.0,
+        "defense": 1.0,
+        "intelligence": 3.0
+      },
+      "UNCOMMON": {
+        "health": 1.0,
+        "defense": 2.0,
+        "intelligence": 4.0
+      },
+      "RARE": {
+        "health": 2.0,
+        "defense": 2.0,
+        "intelligence": 5.0
+      },
+      "EPIC": {
+        "health": 3.0,
+        "defense": 3.0,
+        "intelligence": 6.0
+      },
+      "LEGENDARY": {
+        "health": 4.0,
+        "defense": 4.0,
+        "intelligence": 8.0
+      },
+      "MYTHIC": {
+        "health": 5.0,
+        "defense": 5.0,
+        "intelligence": 10.0
+      }
+    }
+  },
+  "Awkward": {
+    "reforgeName": "Awkward",
+    "itemType": "BOW",
+    "reforgeStats": {
+      "COMMON": {
+        "intelligence": -5.0,
+        "crit_damage": 5.0,
+        "crit_chance": 10.0
+      },
+      "UNCOMMON": {
+        "intelligence": -10.0,
+        "crit_damage": 10.0,
+        "crit_chance": 12.0
+      },
+      "RARE": {
+        "intelligence": -18.0,
+        "crit_damage": 15.0,
+        "crit_chance": 15.0
+      },
+      "EPIC": {
+        "intelligence": -32.0,
+        "crit_damage": 22.0,
+        "crit_chance": 20.0
+      },
+      "LEGENDARY": {
+        "intelligence": -50.0,
+        "crit_damage": 30.0,
+        "crit_chance": 25.0
+      },
+      "MYTHIC": {
+        "intelligence": -72.0,
+        "crit_damage": 35.0,
+        "crit_chance": 30.0
+      }
+    }
+  },
+  "Blended": {
+    "reforgeName": "Blended",
+    "itemType": "EQUIPMENT",
+    "reforgeStats": {
+      "COMMON": {
+        "health": 1.0,
+        "defense": 1.0,
+        "strength": 0.0,
+        "intelligence": 1.0,
+        "crit_damage": 1.0,
+        "crit_chance": 1.0,
+        "bonus_attack_speed": 1.0,
+        "speed": 1.0
+      },
+      "UNCOMMON": {
+        "health": 1.0,
+        "defense": 1.0,
+        "strength": 1.0,
+        "intelligence": 1.0,
+        "crit_damage": 2.0,
+        "crit_chance": 1.0,
+        "bonus_attack_speed": 1.0,
+        "speed": 1.0
+      },
+      "RARE": {
+        "health": 2.0,
+        "defense": 1.0,
+        "strength": 1.0,
+        "intelligence": 1.0,
+        "crit_damage": 2.0,
+        "crit_chance": 2.0,
+        "bonus_attack_speed": 1.0,
+        "speed": 1.0
+      },
+      "EPIC": {
+        "health": 2.0,
+        "defense": 2.0,
+        "strength": 2.0,
+        "intelligence": 2.0,
+        "crit_damage": 2.0,
+        "crit_chance": 2.0,
+        "bonus_attack_speed": 1.0,
+        "speed": 1.0
+      },
+      "LEGENDARY": {
+        "health": 2.0,
+        "defense": 3.0,
+        "strength": 2.0,
+        "intelligence": 2.0,
+        "crit_damage": 2.0,
+        "crit_chance": 3.0,
+        "bonus_attack_speed": 1.0,
+        "speed": 1.0
+      },
+      "MYTHIC": {
+        "health": 3.0,
+        "defense": 3.0,
+        "strength": 2.0,
+        "intelligence": 3.0,
+        "crit_damage": 2.0,
+        "crit_chance": 3.0,
+        "bonus_attack_speed": 1.0,
+        "speed": 1.0
+      }
+    }
+  },
+  "Brilliant": {
+    "reforgeName": "Brilliant",
+    "itemType": "EQUIPMENT",
+    "reforgeStats": {
+      "COMMON": {
+        "health": 1.0,
+        "intelligence": 5.0,
+        "speed": 1.0
+      },
+      "UNCOMMON": {
+        "health": 1.0,
+        "intelligence": 6.0,
+        "speed": 1.0
+      },
+      "RARE": {
+        "health": 2.0,
+        "intelligence": 7.0,
+        "speed": 2.0
+      },
+      "EPIC": {
+        "health": 3.0,
+        "intelligence": 9.0,
+        "speed": 2.0
+      },
+      "LEGENDARY": {
+        "health": 4.0,
+        "intelligence": 12.0,
+        "speed": 2.0
+      },
+      "MYTHIC": {
+        "health": 5.0,
+        "intelligence": 15.0,
+        "speed": 2.0
+      }
+    }
+  },
+  "Clean": {
+    "reforgeName": "Clean",
+    "itemType": "ARMOR",
+    "reforgeStats": {
+      "COMMON": {
+        "health": 5.0,
+        "defense": 5.0,
+        "crit_chance": 2.0
+      },
+      "UNCOMMON": {
+        "health": 7.0,
+        "defense": 7.0,
+        "crit_chance": 4.0
+      },
+      "RARE": {
+        "health": 10.0,
+        "defense": 10.0,
+        "crit_chance": 6.0
+      },
+      "EPIC": {
+        "health": 15.0,
+        "defense": 15.0,
+        "crit_chance": 8.0
+      },
+      "LEGENDARY": {
+        "health": 20.0,
+        "defense": 20.0,
+        "crit_chance": 10.0
+      },
+      "MYTHIC": {
+        "health": 25.0,
+        "defense": 25.0,
+        "crit_chance": 12.0
+      }
+    }
+  },
+  "Colossal": {
+    "reforgeName": "Colossal",
+    "itemType": "EQUIPMENT",
+    "reforgeStats": {
+      "COMMON": {
+        "health": 3.0,
+        "defense": 3.0
+      },
+      "UNCOMMON": {
+        "health": 4.0,
+        "defense": 4.0
+      },
+      "RARE": {
+        "health": 6.0,
+        "defense": 6.0
+      },
+      "EPIC": {
+        "health": 8.0,
+        "defense": 8.0
+      },
+      "LEGENDARY": {
+        "health": 10.0,
+        "defense": 10.0
+      },
+      "MYTHIC": {
+        "health": 12.0,
+        "defense": 12.0
+      }
+    }
+  },
+  "Deadly": {
+    "reforgeName": "Deadly",
+    "itemType": "BOW",
+    "reforgeStats": {
+      "COMMON": {
+        "crit_damage": 5.0,
+        "crit_chance": 10.0
+      },
+      "UNCOMMON": {
+        "crit_damage": 10.0,
+        "crit_chance": 13.0
+      },
+      "RARE": {
+        "crit_damage": 18.0,
+        "crit_chance": 16.0
+      },
+      "EPIC": {
+        "crit_damage": 32.0,
+        "crit_chance": 19.0
+      },
+      "LEGENDARY": {
+        "crit_damage": 50.0,
+        "crit_chance": 22.0
+      },
+      "MYTHIC": {
+        "crit_damage": 78.0,
+        "crit_chance": 25.0
+      }
+    }
+  },
+  "Double-Bit": {
+    "reforgeName": "Double-Bit",
+    "itemType": "AXE",
+    "reforgeStats": {
+      "COMMON": {
+        "speed": 1.0,
+        "foraging_fortune": 1.0
+      },
+      "UNCOMMON": {
+        "speed": 2.0,
+        "foraging_fortune": 2.0
+      },
+      "RARE": {
+        "speed": 2.0,
+        "foraging_fortune": 3.0
+      },
+      "EPIC": {
+        "speed": 3.0,
+        "foraging_fortune": 4.0
+      },
+      "LEGENDARY": {
+        "speed": 5.0,
+        "foraging_fortune": 5.0
+      },
+      "MYTHIC": {
+        "speed": 7.0,
+        "foraging_fortune": 6.0
+      }
+    }
+  },
+  "Epic": {
+    "reforgeName": "Epic",
+    "itemType": "SWORD/ROD",
+    "reforgeStats": {
+      "COMMON": {
+        "strength": 15.0,
+        "crit_damage": 10.0,
+        "bonus_attack_speed": 1.0
+      },
+      "UNCOMMON": {
+        "strength": 20.0,
+        "crit_damage": 15.0,
+        "bonus_attack_speed": 2.0
+      },
+      "RARE": {
+        "strength": 25.0,
+        "crit_damage": 20.0,
+        "bonus_attack_speed": 4.0
+      },
+      "EPIC": {
+        "strength": 32.0,
+        "crit_damage": 27.0,
+        "bonus_attack_speed": 7.0
+      },
+      "LEGENDARY": {
+        "strength": 40.0,
+        "crit_damage": 35.0,
+        "bonus_attack_speed": 10.0
+      },
+      "MYTHIC": {
+        "strength": 50.0,
+        "crit_damage": 45.0,
+        "bonus_attack_speed": 15.0
+      }
+    }
+  },
+  "Excellent": {
+    "reforgeName": "Excellent",
+    "itemType": "PICKAXE",
+    "reforgeStats": {
+      "COMMON": {
+        "speed": 1.0,
+        "mining_speed": 4.0
+      },
+      "UNCOMMON": {
+        "speed": 2.0,
+        "mining_speed": 8.0
+      },
+      "RARE": {
+        "speed": 3.0,
+        "mining_speed": 12.0
+      },
+      "EPIC": {
+        "speed": 4.0,
+        "mining_speed": 16.0
+      },
+      "LEGENDARY": {
+        "speed": 5.0,
+        "mining_speed": 20.0
+      },
+      "MYTHIC": {
+        "speed": 7.0,
+        "mining_speed": 25.0
+      }
+    }
+  },
+  "Fair": {
+    "reforgeName": "Fair",
+    "itemType": "SWORD/ROD",
+    "reforgeStats": {
+      "COMMON": {
+        "strength": 2.0,
+        "intelligence": 2.0,
+        "crit_damage": 2.0,
+        "crit_chance": 2.0,
+        "bonus_attack_speed": 2.0
+      },
+      "UNCOMMON": {
+        "strength": 3.0,
+        "intelligence": 3.0,
+        "crit_damage": 3.0,
+        "crit_chance": 3.0,
+        "bonus_attack_speed": 3.0
+      },
+      "RARE": {
+        "strength": 4.0,
+        "intelligence": 4.0,
+        "crit_damage": 4.0,
+        "crit_chance": 4.0,
+        "bonus_attack_speed": 4.0
+      },
+      "EPIC": {
+        "strength": 7.0,
+        "intelligence": 7.0,
+        "crit_damage": 7.0,
+        "crit_chance": 7.0,
+        "bonus_attack_speed": 7.0
+      },
+      "LEGENDARY": {
+        "strength": 10.0,
+        "intelligence": 10.0,
+        "crit_damage": 10.0,
+        "crit_chance": 10.0,
+        "bonus_attack_speed": 10.0
+      },
+      "MYTHIC": {
+        "strength": 12.0,
+        "intelligence": 12.0,
+        "crit_damage": 12.0,
+        "crit_chance": 12.0,
+        "bonus_attack_speed": 12.0
+      }
+    }
+  },
+  "Fast": {
+    "reforgeName": "Fast",
+    "itemType": "SWORD/ROD",
+    "reforgeStats": {
+      "COMMON": {
+        "bonus_attack_speed": 10.0
+      },
+      "UNCOMMON": {
+        "bonus_attack_speed": 20.0
+      },
+      "RARE": {
+        "bonus_attack_speed": 30.0
+      },
+      "EPIC": {
+        "bonus_attack_speed": 40.0
+      },
+      "LEGENDARY": {
+        "bonus_attack_speed": 50.0
+      },
+      "MYTHIC": {
+        "bonus_attack_speed": 60.0
+      }
+    }
+  },
+  "Fierce": {
+    "reforgeName": "Fierce",
+    "itemType": "ARMOR",
+    "reforgeStats": {
+      "COMMON": {
+        "strength": 2.0,
+        "crit_damage": 4.0,
+        "crit_chance": 2.0
+      },
+      "UNCOMMON": {
+        "strength": 4.0,
+        "crit_damage": 7.0,
+        "crit_chance": 3.0
+      },
+      "RARE": {
+        "strength": 6.0,
+        "crit_damage": 10.0,
+        "crit_chance": 4.0
+      },
+      "EPIC": {
+        "strength": 8.0,
+        "crit_damage": 14.0,
+        "crit_chance": 5.0
+      },
+      "LEGENDARY": {
+        "strength": 10.0,
+        "crit_damage": 18.0,
+        "crit_chance": 6.0
+      },
+      "MYTHIC": {
+        "strength": 12.0,
+        "crit_damage": 24.0,
+        "crit_chance": 8.0
+      }
+    }
+  },
+  "Fine": {
+    "reforgeName": "Fine",
+    "itemType": "BOW",
+    "reforgeStats": {
+      "COMMON": {
+        "strength": 3.0,
+        "crit_damage": 2.0,
+        "crit_chance": 5.0
+      },
+      "UNCOMMON": {
+        "strength": 7.0,
+        "crit_damage": 4.0,
+        "crit_chance": 7.0
+      },
+      "RARE": {
+        "strength": 12.0,
+        "crit_damage": 7.0,
+        "crit_chance": 9.0
+      },
+      "EPIC": {
+        "strength": 18.0,
+        "crit_damage": 10.0,
+        "crit_chance": 12.0
+      },
+      "LEGENDARY": {
+        "strength": 25.0,
+        "crit_damage": 15.0,
+        "crit_chance": 15.0
+      },
+      "MYTHIC": {
+        "strength": 33.0,
+        "crit_damage": 20.0,
+        "crit_chance": 18.0
+      }
+    }
+  },
+  "Fortunate": {
+    "reforgeName": "Fortunate",
+    "itemType": "PICKAXE",
+    "reforgeStats": {
+      "COMMON": {
+        "mining_speed": 1.0,
+        "mining_fortune": 1.0
+      },
+      "UNCOMMON": {
+        "mining_speed": 2.0,
+        "mining_fortune": 1.0
+      },
+      "RARE": {
+        "mining_speed": 3.0,
+        "mining_fortune": 1.0
+      },
+      "EPIC": {
+        "mining_speed": 4.0,
+        "mining_fortune": 2.0
+      },
+      "LEGENDARY": {
+        "mining_speed": 6.0,
+        "mining_fortune": 2.0
+      },
+      "MYTHIC": {
+        "mining_speed": 8.0,
+        "mining_fortune": 3.0
+      }
+    }
+  },
+  "Gentle": {
+    "reforgeName": "Gentle",
+    "itemType": "SWORD/ROD",
+    "reforgeStats": {
+      "COMMON": {
+        "strength": 3.0,
+        "bonus_attack_speed": 8.0
+      },
+      "UNCOMMON": {
+        "strength": 5.0,
+        "bonus_attack_speed": 10.0
+      },
+      "RARE": {
+        "strength": 7.0,
+        "bonus_attack_speed": 15.0
+      },
+      "EPIC": {
+        "strength": 10.0,
+        "bonus_attack_speed": 20.0
+      },
+      "LEGENDARY": {
+        "strength": 15.0,
+        "bonus_attack_speed": 25.0
+      },
+      "MYTHIC": {
+        "strength": 20.0,
+        "bonus_attack_speed": 30.0
+      }
+    }
+  },
+  "Grand": {
+    "reforgeName": "Grand",
+    "itemType": "BOW",
+    "reforgeStats": {
+      "COMMON": {
+        "strength": 25.0
+      },
+      "UNCOMMON": {
+        "strength": 32.0
+      },
+      "RARE": {
+        "strength": 40.0
+      },
+      "EPIC": {
+        "strength": 50.0
+      },
+      "LEGENDARY": {
+        "strength": 60.0
+      },
+      "MYTHIC": {
+        "strength": 75.0
+      }
+    }
+  },
+  "Great": {
+    "reforgeName": "Great",
+    "itemType": "AXE",
+    "reforgeStats": {
+      "COMMON": {
+        "strength": 2.0,
+        "crit_damage": 2.0,
+        "speed": 1.0
+      },
+      "UNCOMMON": {
+        "strength": 4.0,
+        "crit_damage": 4.0,
+        "speed": 2.0
+      },
+      "RARE": {
+        "strength": 6.0,
+        "crit_damage": 6.0,
+        "speed": 3.0
+      },
+      "EPIC": {
+        "strength": 9.0,
+        "crit_damage": 9.0,
+        "speed": 4.0
+      },
+      "LEGENDARY": {
+        "strength": 12.0,
+        "crit_damage": 12.0,
+        "speed": 5.0
+      },
+      "MYTHIC": {
+        "strength": 16.0,
+        "crit_damage": 16.0,
+        "speed": 7.0
+      }
+    }
+  },
+  "Green Thumb": {
+    "reforgeName": "Green Thumb",
+    "itemType": "HOE",
+    "reforgeStats": {
+      "COMMON": {
+        "speed": 1.0,
+        "farming_fortune": 1.0
+      },
+      "UNCOMMON": {
+        "speed": 2.0,
+        "farming_fortune": 2.0
+      },
+      "RARE": {
+        "speed": 2.0,
+        "farming_fortune": 3.0
+      },
+      "EPIC": {
+        "speed": 3.0,
+        "farming_fortune": 4.0
+      },
+      "LEGENDARY": {
+        "speed": 5.0,
+        "farming_fortune": 5.0
+      },
+      "MYTHIC": {
+        "speed": 7.0,
+        "farming_fortune": 6.0
+      }
+    }
+  },
+  "Hasty": {
+    "reforgeName": "Hasty",
+    "itemType": "BOW",
+    "reforgeStats": {
+      "COMMON": {
+        "strength": 3.0,
+        "crit_chance": 20.0
+      },
+      "UNCOMMON": {
+        "strength": 5.0,
+        "crit_chance": 25.0
+      },
+      "RARE": {
+        "strength": 7.0,
+        "crit_chance": 30.0
+      },
+      "EPIC": {
+        "strength": 10.0,
+        "crit_chance": 40.0
+      },
+      "LEGENDARY": {
+        "strength": 15.0,
+        "crit_chance": 50.0
+      },
+      "MYTHIC": {
+        "strength": 20.0,
+        "crit_chance": 60.0
+      }
+    }
+  },
+  "Heavy": {
+    "reforgeName": "Heavy",
+    "itemType": "ARMOR",
+    "reforgeStats": {
+      "COMMON": {
+        "defense": 25.0,
+        "crit_damage": -1.0,
+        "speed": -1.0
+      },
+      "UNCOMMON": {
+        "defense": 35.0,
+        "crit_damage": -2.0,
+        "speed": -1.0
+      },
+      "RARE": {
+        "defense": 50.0,
+        "crit_damage": -2.0,
+        "speed": -1.0
+      },
+      "EPIC": {
+        "defense": 65.0,
+        "crit_damage": -3.0,
+        "speed": -1.0
+      },
+      "LEGENDARY": {
+        "defense": 80.0,
+        "crit_damage": -5.0,
+        "speed": -1.0
+      },
+      "MYTHIC": {
+        "defense": 110.0,
+        "crit_damage": -7.0,
+        "speed": -1.0
+      }
+    }
+  },
+  "Hefty": {
+    "reforgeName": "Hefty",
+    "itemType": "EQUIPMENT",
+    "reforgeStats": {
+      "COMMON": {
+        "defense": 7.0,
+        "crit_damage": -2.0,
+        "speed": -1.0
+      },
+      "UNCOMMON": {
+        "defense": 9.0,
+        "crit_damage": -2.0,
+        "speed": -1.0
+      },
+      "RARE": {
+        "defense": 12.0,
+        "crit_damage": -3.0,
+        "speed": -1.0
+      },
+      "EPIC": {
+        "defense": 15.0,
+        "crit_damage": -3.0,
+        "speed": -1.0
+      },
+      "LEGENDARY": {
+        "defense": 20.0,
+        "crit_damage": -4.0,
+        "speed": -1.0
+      },
+      "MYTHIC": {
+        "defense": 25.0,
+        "crit_damage": -5.0,
+        "speed": -1.0
+      }
+    }
+  },
+  "Heroic": {
+    "reforgeName": "Heroic",
+    "itemType": "SWORD/ROD",
+    "reforgeStats": {
+      "COMMON": {
+        "strength": 15.0,
+        "intelligence": 40.0,
+        "bonus_attack_speed": 1.0
+      },
+      "UNCOMMON": {
+        "strength": 20.0,
+        "intelligence": 50.0,
+        "bonus_attack_speed": 2.0
+      },
+      "RARE": {
+        "strength": 25.0,
+        "intelligence": 65.0,
+        "bonus_attack_speed": 2.0
+      },
+      "EPIC": {
+        "strength": 32.0,
+        "intelligence": 80.0,
+        "bonus_attack_speed": 3.0
+      },
+      "LEGENDARY": {
+        "strength": 40.0,
+        "intelligence": 100.0,
+        "bonus_attack_speed": 5.0
+      },
+      "MYTHIC": {
+        "strength": 50.0,
+        "intelligence": 125.0,
+        "bonus_attack_speed": 7.0
+      }
+    }
+  },
+  "Honored": {
+    "reforgeName": "Honored",
+    "itemType": "EQUIPMENT",
+    "reforgeStats": {
+      "COMMON": {
+        "health": 1.0,
+        "defense": 1.0,
+        "strength": 0.0,
+        "intelligence": 3.0,
+        "crit_chance": 1.0,
+        "speed": 1.0
+      },
+      "UNCOMMON": {
+        "health": 1.0,
+        "defense": 2.0,
+        "strength": 1.0,
+        "intelligence": 3.0,
+        "crit_chance": 1.0,
+        "speed": 1.0
+      },
+      "RARE": {
+        "health": 2.0,
+        "defense": 2.0,
+        "strength": 2.0,
+        "intelligence": 4.0,
+        "crit_chance": 1.0,
+        "speed": 1.0
+      },
+      "EPIC": {
+        "health": 2.0,
+        "defense": 3.0,
+        "strength": 2.0,
+        "intelligence": 5.0,
+        "crit_chance": 2.0,
+        "speed": 1.0
+      },
+      "LEGENDARY": {
+        "health": 3.0,
+        "defense": 3.0,
+        "strength": 3.0,
+        "intelligence": 6.0,
+        "crit_chance": 2.0,
+        "speed": 1.0
+      },
+      "MYTHIC": {
+        "health": 4.0,
+        "defense": 4.0,
+        "strength": 3.0,
+        "intelligence": 7.0,
+        "crit_chance": 2.0,
+        "speed": 1.0
+      }
+    }
+  },
+  "Legendary": {
+    "reforgeName": "Legendary",
+    "itemType": "SWORD/ROD",
+    "reforgeStats": {
+      "COMMON": {
+        "strength": 3.0,
+        "intelligence": 5.0,
+        "crit_damage": 5.0,
+        "crit_chance": 5.0,
+        "bonus_attack_speed": 2.0
+      },
+      "UNCOMMON": {
+        "strength": 7.0,
+        "intelligence": 8.0,
+        "crit_damage": 10.0,
+        "crit_chance": 7.0,
+        "bonus_attack_speed": 3.0
+      },
+      "RARE": {
+        "strength": 12.0,
+        "intelligence": 12.0,
+        "crit_damage": 15.0,
+        "crit_chance": 9.0,
+        "bonus_attack_speed": 5.0
+      },
+      "EPIC": {
+        "strength": 18.0,
+        "intelligence": 18.0,
+        "crit_damage": 22.0,
+        "crit_chance": 12.0,
+        "bonus_attack_speed": 7.0
+      },
+      "LEGENDARY": {
+        "strength": 25.0,
+        "intelligence": 25.0,
+        "crit_damage": 28.0,
+        "crit_chance": 15.0,
+        "bonus_attack_speed": 10.0
+      },
+      "MYTHIC": {
+        "strength": 32.0,
+        "intelligence": 35.0,
+        "crit_damage": 36.0,
+        "crit_chance": 18.0,
+        "bonus_attack_speed": 15.0
+      }
+    }
+  },
+  "Light": {
+    "reforgeName": "Light",
+    "itemType": "ARMOR",
+    "reforgeStats": {
+      "COMMON": {
+        "health": 5.0,
+        "defense": 1.0,
+        "crit_damage": 1.0,
+        "crit_chance": 1.0,
+        "bonus_attack_speed": 1.0,
+        "speed": 1.0
+      },
+      "UNCOMMON": {
+        "health": 7.0,
+        "defense": 2.0,
+        "crit_damage": 2.0,
+        "crit_chance": 1.0,
+        "bonus_attack_speed": 2.0,
+        "speed": 2.0
+      },
+      "RARE": {
+        "health": 10.0,
+        "defense": 3.0,
+        "crit_damage": 3.0,
+        "crit_chance": 2.0,
+        "bonus_attack_speed": 3.0,
+        "speed": 3.0
+      },
+      "EPIC": {
+        "health": 15.0,
+        "defense": 4.0,
+        "crit_damage": 4.0,
+        "crit_chance": 2.0,
+        "bonus_attack_speed": 4.0,
+        "speed": 4.0
+      },
+      "LEGENDARY": {
+        "health": 20.0,
+        "defense": 5.0,
+        "crit_damage": 5.0,
+        "crit_chance": 3.0,
+        "bonus_attack_speed": 5.0,
+        "speed": 5.0
+      },
+      "MYTHIC": {
+        "health": 25.0,
+        "defense": 6.0,
+        "crit_damage": 6.0,
+        "crit_chance": 3.0,
+        "bonus_attack_speed": 6.0,
+        "speed": 6.0
+      }
+    }
+  },
+  "Lumberjack\u0027s": {
+    "reforgeName": "Lumberjack\u0027s",
+    "itemType": "AXE",
+    "reforgeStats": {
+      "COMMON": {
+        "speed": 1.0,
+        "foraging_wisdom": 0.5
+      },
+      "UNCOMMON": {
+        "speed": 2.0,
+        "foraging_wisdom": 0.75
+      },
+      "RARE": {
+        "speed": 3.0,
+        "foraging_wisdom": 1.0
+      },
+      "EPIC": {
+        "speed": 5.0,
+        "foraging_wisdom": 1.25
+      },
+      "LEGENDARY": {
+        "speed": 7.0,
+        "foraging_wisdom": 2.0
+      },
+      "MYTHIC": {
+        "speed": 9.0,
+        "foraging_wisdom": 2.5
+      }
+    }
+  },
+  "Lush": {
+    "reforgeName": "Lush",
+    "itemType": "AXE",
+    "reforgeStats": {
+      "COMMON": {
+        "speed": 3.0,
+        "foraging_fortune": 1.0
+      },
+      "UNCOMMON": {
+        "speed": 4.0,
+        "foraging_fortune": 1.0
+      },
+      "RARE": {
+        "speed": 5.0,
+        "foraging_fortune": 2.0
+      },
+      "EPIC": {
+        "speed": 7.0,
+        "foraging_fortune": 2.0
+      },
+      "LEGENDARY": {
+        "speed": 10.0,
+        "foraging_fortune": 3.0
+      },
+      "MYTHIC": {
+        "speed": 15.0,
+        "foraging_fortune": 5.0
+      }
+    }
+  },
+  "Menacing": {
+    "reforgeName": "Menacing",
+    "itemType": "EQUIPMENT",
+    "reforgeStats": {
+      "COMMON": {
+        "crit_damage": 2.0,
+        "crit_chance": 1.0
+      },
+      "UNCOMMON": {
+        "crit_damage": 3.0,
+        "crit_chance": 1.0
+      },
+      "RARE": {
+        "crit_damage": 3.0,
+        "crit_chance": 1.0
+      },
+      "EPIC": {
+        "crit_damage": 4.0,
+        "crit_chance": 1.0
+      },
+      "LEGENDARY": {
+        "crit_damage": 4.0,
+        "crit_chance": 2.0
+      },
+      "MYTHIC": {
+        "crit_damage": 5.0,
+        "crit_chance": 2.0
+      }
+    }
+  },
+  "Mythic": {
+    "reforgeName": "Mythic",
+    "itemType": "ARMOR",
+    "reforgeStats": {
+      "COMMON": {
+        "health": 2.0,
+        "defense": 2.0,
+        "strength": 2.0,
+        "intelligence": 20.0,
+        "crit_chance": 1.0,
+        "speed": 2.0
+      },
+      "UNCOMMON": {
+        "health": 4.0,
+        "defense": 3.0,
+        "strength": 4.0,
+        "intelligence": 25.0,
+        "crit_chance": 2.0,
+        "speed": 2.0
+      },
+      "RARE": {
+        "health": 6.0,
+        "defense": 6.0,
+        "strength": 6.0,
+        "intelligence": 30.0,
+        "crit_chance": 3.0,
+        "speed": 2.0
+      },
+      "EPIC": {
+        "health": 8.0,
+        "defense": 8.0,
+        "strength": 8.0,
+        "intelligence": 40.0,
+        "crit_chance": 4.0,
+        "speed": 2.0
+      },
+      "LEGENDARY": {
+        "health": 10.0,
+        "defense": 10.0,
+        "strength": 10.0,
+        "intelligence": 50.0,
+        "crit_chance": 5.0,
+        "speed": 2.0
+      },
+      "MYTHIC": {
+        "health": 12.0,
+        "defense": 12.0,
+        "strength": 12.0,
+        "intelligence": 60.0,
+        "crit_chance": 6.0,
+        "speed": 2.0
+      }
+    }
+  },
+  "Neat": {
+    "reforgeName": "Neat",
+    "itemType": "BOW",
+    "reforgeStats": {
+      "COMMON": {
+        "intelligence": 3.0,
+        "crit_damage": 4.0,
+        "crit_chance": 10.0
+      },
+      "UNCOMMON": {
+        "intelligence": 6.0,
+        "crit_damage": 8.0,
+        "crit_chance": 12.0
+      },
+      "RARE": {
+        "intelligence": 10.0,
+        "crit_damage": 14.0,
+        "crit_chance": 14.0
+      },
+      "EPIC": {
+        "intelligence": 15.0,
+        "crit_damage": 20.0,
+        "crit_chance": 17.0
+      },
+      "LEGENDARY": {
+        "intelligence": 20.0,
+        "crit_damage": 30.0,
+        "crit_chance": 20.0
+      },
+      "MYTHIC": {
+        "intelligence": 30.0,
+        "crit_damage": 40.0,
+        "crit_chance": 25.0
+      }
+    }
+  },
+  "Odd": {
+    "reforgeName": "Odd",
+    "itemType": "SWORD/ROD",
+    "reforgeStats": {
+      "COMMON": {
+        "intelligence": -5.0,
+        "crit_damage": 5.0,
+        "crit_chance": 10.0
+      },
+      "UNCOMMON": {
+        "intelligence": -10.0,
+        "crit_damage": 10.0,
+        "crit_chance": 12.0
+      },
+      "RARE": {
+        "intelligence": -18.0,
+        "crit_damage": 15.0,
+        "crit_chance": 15.0
+      },
+      "EPIC": {
+        "intelligence": -32.0,
+        "crit_damage": 22.0,
+        "crit_chance": 20.0
+      },
+      "LEGENDARY": {
+        "intelligence": -50.0,
+        "crit_damage": 30.0,
+        "crit_chance": 25.0
+      },
+      "MYTHIC": {
+        "intelligence": -75.0,
+        "crit_damage": 40.0,
+        "crit_chance": 30.0
+      }
+    }
+  },
+  "Peasant\u0027s": {
+    "reforgeName": "Peasant\u0027s",
+    "itemType": "HOE",
+    "reforgeStats": {
+      "COMMON": {
+        "speed": 1.0,
+        "farming_wisdom": 0.5
+      },
+      "UNCOMMON": {
+        "speed": 2.0,
+        "farming_wisdom": 0.75
+      },
+      "RARE": {
+        "speed": 3.0,
+        "farming_wisdom": 1.0
+      },
+      "EPIC": {
+        "speed": 5.0,
+        "farming_wisdom": 1.25
+      },
+      "LEGENDARY": {
+        "speed": 7.0,
+        "farming_wisdom": 2.0
+      },
+      "MYTHIC": {
+        "speed": 9.0,
+        "farming_wisdom": 2.5
+      }
+    }
+  },
+  "Prospector\u0027s": {
+    "reforgeName": "Prospector\u0027s",
+    "itemType": "PICKAXE",
+    "reforgeStats": {
+      "COMMON": {
+        "speed": 1.0,
+        "mining_wisdom": 0.5
+      },
+      "UNCOMMON": {
+        "speed": 2.0,
+        "mining_wisdom": 0.75
+      },
+      "RARE": {
+        "speed": 3.0,
+        "mining_wisdom": 1.0
+      },
+      "EPIC": {
+        "speed": 5.0,
+        "mining_wisdom": 1.25
+      },
+      "LEGENDARY": {
+        "speed": 7.0,
+        "mining_wisdom": 2.0
+      },
+      "MYTHIC": {
+        "speed": 9.0,
+        "mining_wisdom": 2.5
+      }
+    }
+  },
+  "Pure": {
+    "reforgeName": "Pure",
+    "itemType": "ARMOR",
+    "reforgeStats": {
+      "COMMON": {
+        "health": 2.0,
+        "defense": 2.0,
+        "strength": 2.0,
+        "intelligence": 2.0,
+        "crit_damage": 2.0,
+        "crit_chance": 2.0,
+        "bonus_attack_speed": 1.0,
+        "speed": 1.0
+      },
+      "UNCOMMON": {
+        "health": 3.0,
+        "defense": 3.0,
+        "strength": 3.0,
+        "intelligence": 3.0,
+        "crit_damage": 3.0,
+        "crit_chance": 4.0,
+        "bonus_attack_speed": 1.0,
+        "speed": 1.0
+      },
+      "RARE": {
+        "health": 4.0,
+        "defense": 4.0,
+        "strength": 4.0,
+        "intelligence": 4.0,
+        "crit_damage": 4.0,
+        "crit_chance": 6.0,
+        "bonus_attack_speed": 2.0,
+        "speed": 1.0
+      },
+      "EPIC": {
+        "health": 6.0,
+        "defense": 6.0,
+        "strength": 6.0,
+        "intelligence": 6.0,
+        "crit_damage": 6.0,
+        "crit_chance": 8.0,
+        "bonus_attack_speed": 3.0,
+        "speed": 1.0
+      },
+      "LEGENDARY": {
+        "health": 8.0,
+        "defense": 8.0,
+        "strength": 8.0,
+        "intelligence": 8.0,
+        "crit_damage": 8.0,
+        "crit_chance": 10.0,
+        "bonus_attack_speed": 4.0,
+        "speed": 1.0
+      },
+      "MYTHIC": {
+        "health": 10.0,
+        "defense": 10.0,
+        "strength": 10.0,
+        "intelligence": 10.0,
+        "crit_damage": 10.0,
+        "crit_chance": 12.0,
+        "bonus_attack_speed": 5.0,
+        "speed": 1.0
+      }
+    }
+  },
+  "Rapid": {
+    "reforgeName": "Rapid",
+    "itemType": "BOW",
+    "reforgeStats": {
+      "COMMON": {
+        "strength": 2.0,
+        "crit_damage": 35.0
+      },
+      "UNCOMMON": {
+        "strength": 3.0,
+        "crit_damage": 45.0
+      },
+      "RARE": {
+        "strength": 4.0,
+        "crit_damage": 55.0
+      },
+      "EPIC": {
+        "strength": 7.0,
+        "crit_damage": 65.0
+      },
+      "LEGENDARY": {
+        "strength": 10.0,
+        "crit_damage": 75.0
+      },
+      "MYTHIC": {
+        "strength": 12.0,
+        "crit_damage": 90.0
+      }
+    }
+  },
+  "Rich": {
+    "reforgeName": "Rich",
+    "itemType": "BOW",
+    "reforgeStats": {
+      "COMMON": {
+        "intelligence": 3.0,
+        "crit_damage": 2.0,
+        "crit_chance": 10.0
+      },
+      "UNCOMMON": {
+        "intelligence": 5.0,
+        "crit_damage": 4.0,
+        "crit_chance": 12.0
+      },
+      "RARE": {
+        "intelligence": 6.0,
+        "crit_damage": 7.0,
+        "crit_chance": 14.0
+      },
+      "EPIC": {
+        "intelligence": 15.0,
+        "crit_damage": 10.0,
+        "crit_chance": 17.0
+      },
+      "LEGENDARY": {
+        "intelligence": 20.0,
+        "crit_damage": 15.0,
+        "crit_chance": 20.0
+      },
+      "MYTHIC": {
+        "intelligence": 30.0,
+        "crit_damage": 20.0,
+        "crit_chance": 25.0
+      }
+    }
+  },
+  "Robust": {
+    "reforgeName": "Robust",
+    "itemType": "HOE",
+    "reforgeStats": {
+      "COMMON": {
+        "farming_fortune": 2.0
+      },
+      "UNCOMMON": {
+        "farming_fortune": 3.0
+      },
+      "RARE": {
+        "farming_fortune": 4.0
+      },
+      "EPIC": {
+        "farming_fortune": 6.0
+      },
+      "LEGENDARY": {
+        "farming_fortune": 8.0
+      },
+      "MYTHIC": {
+        "farming_fortune": 10.0
+      }
+    }
+  },
+  "Rugged": {
+    "reforgeName": "Rugged",
+    "itemType": "AXE",
+    "reforgeStats": {
+      "COMMON": {
+        "strength": 4.0,
+        "crit_damage": 3.0
+      },
+      "UNCOMMON": {
+        "strength": 6.0,
+        "crit_damage": 5.0
+      },
+      "RARE": {
+        "strength": 9.0,
+        "crit_damage": 8.0
+      },
+      "EPIC": {
+        "strength": 13.0,
+        "crit_damage": 12.0
+      },
+      "LEGENDARY": {
+        "strength": 18.0,
+        "crit_damage": 16.0
+      },
+      "MYTHIC": {
+        "strength": 24.0,
+        "crit_damage": 22.0
+      }
+    }
+  },
+  "Sharp": {
+    "reforgeName": "Sharp",
+    "itemType": "SWORD/ROD",
+    "reforgeStats": {
+      "COMMON": {
+        "crit_damage": 20.0,
+        "crit_chance": 10.0
+      },
+      "UNCOMMON": {
+        "crit_damage": 30.0,
+        "crit_chance": 12.0
+      },
+      "RARE": {
+        "crit_damage": 40.0,
+        "crit_chance": 14.0
+      },
+      "EPIC": {
+        "crit_damage": 55.0,
+        "crit_chance": 17.0
+      },
+      "LEGENDARY": {
+        "crit_damage": 75.0,
+        "crit_chance": 20.0
+      },
+      "MYTHIC": {
+        "crit_damage": 90.0,
+        "crit_chance": 25.0
+      }
+    }
+  },
+  "Smart": {
+    "reforgeName": "Smart",
+    "itemType": "ARMOR",
+    "reforgeStats": {
+      "COMMON": {
+        "health": 4.0,
+        "defense": 4.0,
+        "intelligence": 20.0
+      },
+      "UNCOMMON": {
+        "health": 6.0,
+        "defense": 6.0,
+        "intelligence": 40.0
+      },
+      "RARE": {
+        "health": 9.0,
+        "defense": 9.0,
+        "intelligence": 60.0
+      },
+      "EPIC": {
+        "health": 12.0,
+        "defense": 12.0,
+        "intelligence": 80.0
+      },
+      "LEGENDARY": {
+        "health": 15.0,
+        "defense": 15.0,
+        "intelligence": 100.0
+      },
+      "MYTHIC": {
+        "health": 20.0,
+        "defense": 20.0,
+        "intelligence": 120.0
+      }
+    }
+  },
+  "Soft": {
+    "reforgeName": "Soft",
+    "itemType": "EQUIPMENT",
+    "reforgeStats": {
+      "COMMON": {
+        "health": 2.0,
+        "defense": 1.0,
+        "crit_damage": 1.0,
+        "crit_chance": 1.0,
+        "bonus_attack_speed": 1.0,
+        "speed": 1.0
+      },
+      "UNCOMMON": {
+        "health": 3.0,
+        "defense": 1.0,
+        "crit_damage": 1.0,
+        "crit_chance": 1.0,
+        "bonus_attack_speed": 1.0,
+        "speed": 1.0
+      },
+      "RARE": {
+        "health": 4.0,
+        "defense": 1.0,
+        "crit_damage": 1.0,
+        "crit_chance": 1.0,
+        "bonus_attack_speed": 1.0,
+        "speed": 1.0
+      },
+      "EPIC": {
+        "health": 5.0,
+        "defense": 1.0,
+        "crit_damage": 2.0,
+        "crit_chance": 1.0,
+        "bonus_attack_speed": 1.0,
+        "speed": 1.0
+      },
+      "LEGENDARY": {
+        "health": 6.0,
+        "defense": 2.0,
+        "crit_damage": 2.0,
+        "crit_chance": 1.0,
+        "bonus_attack_speed": 1.0,
+        "speed": 2.0
+      },
+      "MYTHIC": {
+        "health": 7.0,
+        "defense": 2.0,
+        "crit_damage": 2.0,
+        "crit_chance": 1.0,
+        "bonus_attack_speed": 2.0,
+        "speed": 2.0
+      }
+    }
+  },
+  "Spicy": {
+    "reforgeName": "Spicy",
+    "itemType": "SWORD/ROD",
+    "reforgeStats": {
+      "COMMON": {
+        "strength": 2.0,
+        "crit_damage": 25.0,
+        "crit_chance": 1.0,
+        "bonus_attack_speed": 2.0
+      },
+      "UNCOMMON": {
+        "strength": 3.0,
+        "crit_damage": 35.0,
+        "crit_chance": 1.0,
+        "bonus_attack_speed": 3.0
+      },
+      "RARE": {
+        "strength": 4.0,
+        "crit_damage": 45.0,
+        "crit_chance": 1.0,
+        "bonus_attack_speed": 5.0
+      },
+      "EPIC": {
+        "strength": 7.0,
+        "crit_damage": 60.0,
+        "crit_chance": 1.0,
+        "bonus_attack_speed": 7.0
+      },
+      "LEGENDARY": {
+        "strength": 10.0,
+        "crit_damage": 80.0,
+        "crit_chance": 1.0,
+        "bonus_attack_speed": 10.0
+      },
+      "MYTHIC": {
+        "strength": 12.0,
+        "crit_damage": 100.0,
+        "crit_chance": 1.0,
+        "bonus_attack_speed": 15.0
+      }
+    }
+  },
+  "Stained": {
+    "reforgeName": "Stained",
+    "itemType": "EQUIPMENT",
+    "reforgeStats": {
+      "COMMON": {
+        "health": 2.0,
+        "defense": 2.0,
+        "crit_chance": 1.0
+      },
+      "UNCOMMON": {
+        "health": 3.0,
+        "defense": 3.0,
+        "crit_chance": 1.0
+      },
+      "RARE": {
+        "health": 4.0,
+        "defense": 4.0,
+        "crit_chance": 2.0
+      },
+      "EPIC": {
+        "health": 5.0,
+        "defense": 5.0,
+        "crit_chance": 2.0
+      },
+      "LEGENDARY": {
+        "health": 5.0,
+        "defense": 6.0,
+        "crit_chance": 3.0
+      },
+      "MYTHIC": {
+        "health": 7.0,
+        "defense": 7.0,
+        "crit_chance": 4.0
+      }
+    }
+  },
+  "Sturdy": {
+    "reforgeName": "Sturdy",
+    "itemType": "PICKAXE",
+    "reforgeStats": {
+      "COMMON": {
+        "defense": 3.0,
+        "mining_speed": 3.0
+      },
+      "UNCOMMON": {
+        "defense": 6.0,
+        "mining_speed": 6.0
+      },
+      "RARE": {
+        "defense": 9.0,
+        "mining_speed": 9.0
+      },
+      "EPIC": {
+        "defense": 12.0,
+        "mining_speed": 12.0
+      },
+      "LEGENDARY": {
+        "defense": 15.0,
+        "mining_speed": 15.0
+      },
+      "MYTHIC": {
+        "defense": 20.0,
+        "mining_speed": 20.0
+      }
+    }
+  },
+  "Titanic": {
+    "reforgeName": "Titanic",
+    "itemType": "ARMOR",
+    "reforgeStats": {
+      "COMMON": {
+        "health": 10.0,
+        "defense": 10.0
+      },
+      "UNCOMMON": {
+        "health": 15.0,
+        "defense": 15.0
+      },
+      "RARE": {
+        "health": 20.0,
+        "defense": 20.0
+      },
+      "EPIC": {
+        "health": 25.0,
+        "defense": 25.0
+      },
+      "LEGENDARY": {
+        "health": 35.0,
+        "defense": 35.0
+      },
+      "MYTHIC": {
+        "health": 50.0,
+        "defense": 50.0
+      }
+    }
+  },
+  "Unreal": {
+    "reforgeName": "Unreal",
+    "itemType": "BOW",
+    "reforgeStats": {
+      "COMMON": {
+        "strength": 3.0,
+        "crit_damage": 5.0,
+        "crit_chance": 8.0
+      },
+      "UNCOMMON": {
+        "strength": 7.0,
+        "crit_damage": 10.0,
+        "crit_chance": 9.0
+      },
+      "RARE": {
+        "strength": 12.0,
+        "crit_damage": 18.0,
+        "crit_chance": 10.0
+      },
+      "EPIC": {
+        "strength": 18.0,
+        "crit_damage": 32.0,
+        "crit_chance": 11.0
+      },
+      "LEGENDARY": {
+        "strength": 25.0,
+        "crit_damage": 50.0,
+        "crit_chance": 13.0
+      },
+      "MYTHIC": {
+        "strength": 34.0,
+        "crit_damage": 70.0,
+        "crit_chance": 15.0
+      }
+    }
+  },
+  "Unyielding": {
+    "reforgeName": "Unyielding",
+    "itemType": "PICKAXE",
+    "reforgeStats": {
+      "COMMON": {
+        "speed": 1.0,
+        "mining_fortune": 1.0
+      },
+      "UNCOMMON": {
+        "speed": 2.0,
+        "mining_fortune": 2.0
+      },
+      "RARE": {
+        "speed": 3.0,
+        "mining_fortune": 3.0
+      },
+      "EPIC": {
+        "speed": 5.0,
+        "mining_fortune": 4.0
+      },
+      "LEGENDARY": {
+        "speed": 7.0,
+        "mining_fortune": 5.0
+      },
+      "MYTHIC": {
+        "speed": 9.0,
+        "mining_fortune": 6.0
+      }
+    }
+  },
+  "Wise": {
+    "reforgeName": "Wise",
+    "itemType": "ARMOR",
+    "reforgeStats": {
+      "COMMON": {
+        "health": 6.0,
+        "intelligence": 25.0,
+        "speed": 1.0
+      },
+      "UNCOMMON": {
+        "health": 8.0,
+        "intelligence": 50.0,
+        "speed": 1.0
+      },
+      "RARE": {
+        "health": 10.0,
+        "intelligence": 75.0,
+        "speed": 1.0
+      },
+      "EPIC": {
+        "health": 12.0,
+        "intelligence": 100.0,
+        "speed": 2.0
+      },
+      "LEGENDARY": {
+        "health": 15.0,
+        "intelligence": 125.0,
+        "speed": 2.0
+      },
+      "MYTHIC": {
+        "health": 20.0,
+        "intelligence": 150.0,
+        "speed": 3.0
+      }
+    }
+  },
+  "Zooming": {
+    "reforgeName": "Zooming",
+    "itemType": "HOE",
+    "reforgeStats": {
+      "COMMON": {
+        "speed": 5.0
+      },
+      "UNCOMMON": {
+        "speed": 8.0
+      },
+      "RARE": {
+        "speed": 12.0
+      },
+      "EPIC": {
+        "speed": 16.0
+      },
+      "LEGENDARY": {
+        "speed": 20.0
+      },
+      "MYTHIC": {
+        "speed": 25.0
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds all random reforges.
It can't be added to reforgeStones since the existing format is incompatible with random reforges since it always needs to have a stone and random reforges do not have this.