### PR TITLE
Fixed some enchants

### DIFF
--- a/constants/enchants.json
+++ b/constants/enchants.json
@@ -863,7 +863,7 @@
     ],
     "flame": [
       25,
-      0
+      50
     ],
     "infinite_quiver": [
       10,
@@ -1558,7 +1558,14 @@
     "experience": 3,
     "efficiency": 5,
     "harvesting": 5,
-    "piscary": 5
+    "piscary": 5,
+    "spiked_hook": 5,
+    "caster": 5,
+    "frail": 5,
+    "angler": 5,
+    "chance": 3,
+    "power": 5,
+    "infinite_quiver": 5
   },
   "enchant_mapping_id": [
     "prosecute",


### PR DESCRIPTION
Some enchants lacked a `max_xp_table_levels` attribute which caused the enchant GUI to be buggy, and flame's level 2 was listed as "0" and not "50"