### PR TITLE
Fix max enchant table level on Lure

### DIFF
--- a/constants/enchants.json
+++ b/constants/enchants.json
@@ -1565,7 +1565,8 @@
     "angler": 5,
     "chance": 3,
     "power": 5,
-    "infinite_quiver": 5
+    "infinite_quiver": 5,
+    "lure": 5
   },
   "enchant_mapping_id": [
     "prosecute",


### PR DESCRIPTION
The max enchant table level for Lure was missing which caused Lure 5 to show as costing 50 levels instead of the actual 30 levels in the enchant table overlay. This has been fixed