### PR TITLE
Added more max enchant table levels

### DIFF
--- a/constants/enchants.json
+++ b/constants/enchants.json
@@ -1566,7 +1566,9 @@
     "chance": 3,
     "power": 5,
     "infinite_quiver": 5,
-    "lure": 5
+    "lure": 5,
+    "magnet": 5,
+    "luck_of_the_sea": 5
   },
   "enchant_mapping_id": [
     "prosecute",


### PR DESCRIPTION
Added max enchant table levels for Magnet and Luck of the Sea. This should hopefully be the last of the ones that currently cause bugs. 