### PR TITLE
fix fish the rabbit api name

### DIFF
--- a/constants/hoppity.json
+++ b/constants/hoppity.json
@@ -264,7 +264,7 @@
           "domino",
           "eastwood",
           "ella",
-          "fish_the_rabbit",
+          "fish",
           "fitch",
           "flip_flop",
           "forrest",


### PR DESCRIPTION
For some reason the API name for Fish the Rabbit is just `fish`, not `fish_the_rabbit`.

(example)
<img width="424" alt="Screenshot 2024-06-01 at 3 19 56 PM" src="https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/assets/16139460/10ef1fce-f159-4180-bb91-176cfa8986a3">
