### PR TITLE
Submerged Common fix

### DIFF
--- a/constants/reforgestones.json
+++ b/constants/reforgestones.json
@@ -444,7 +444,8 @@
     "reforgeStats": {
       "COMMON": {
         "crit_chance": 2,
-        "sea_creature_chance": 0.5
+        "sea_creature_chance": 0.5,
+        "fishing_speed": 1
       },
       "UNCOMMON": {
         "crit_chance": 4,


### PR DESCRIPTION
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/assets/85900443/7e9b1741-17be-4505-8eee-f06313788540)
Wiki disagrees with the common rarity of submerged. The wiki says it has 1 Fishing Speed but in the file it misses that stat.

Ehm, also fandom is wrong. I guess.
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/assets/85900443/269b09fd-171a-449c-8218-55c5948222c6)

Real Item
![image](https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO/assets/85900443/00186e56-74f5-4623-8378-f4ffc919feb8)
