### PR TITLE
Add slayer requirement to Rare Wisp upgrade stone

### DIFF
--- a/items/UPGRADE_STONE_FROST.json
+++ b/items/UPGRADE_STONE_FROST.json
@@ -27,6 +27,7 @@
   "internalname": "UPGRADE_STONE_FROST",
   "crafttext": "",
   "clickcommand": "viewrecipe",
+  "slayer_req": "BLAZE_3",
   "modver": "",
   "infoType": "WIKI_URL",
   "info": [


### PR DESCRIPTION
for the other 3 types of upgrade stones the requirement was present.  
Compare to https://wiki.hypixel.net/Wisp_Upgrade_Stone#Rare__