### PR TITLE
Fix: Hotm Daily Powder and Grind always showing 500

### DIFF
--- a/constants/hotmlayout.json
+++ b/constants/hotmlayout.json
@@ -272,15 +272,15 @@
         "powder": "GLACITE",
         "item": "(npi level0 maxLevel)",
         "cost": "0",
-        "stat": "(* level 50)",
+        "stat": "(* (floor hotm) 500)",
         "lore": [
           "§7§7Your first daily commission on each",
           "§7§bMining Island§7 grants §9+500 Powder§7,",
           "§7multiplied by your §5HOTM§7 level.",
           "",
-          "§2Dwarven Mines§7: §a+5,000 §2Mithril Powder",
-          "§5Crystal Hollows§7: §a+5,000 §dGemstone Powder",
-          "§bGlacite Tunnels§7: §a+5,000 §bGlacite Powder"
+          "§2Dwarven Mines§7: §a+{stat} §2Mithril Powder",
+          "§5Crystal Hollows§7: §a+{stat} §dGemstone Powder",
+          "§bGlacite Tunnels§7: §a+{stat} §bGlacite Powder"
         ]
       },
       "special_0": {
@@ -342,15 +342,15 @@
         "powder": "GEMSTONE",
         "item": "(npi level0 maxLevel)",
         "cost": "0",
-        "stat": "(+ 364 (* level 36))",
+        "stat": "(* (floor hotm) 500)",
         "lore": [
           "§7The first ore you mine each day",
           "§7grants §9+500 Powder§7, multiplied by",
           "§7your §5HOTM §7level.",
           "",
-          "§2Mithril§7: §a+5,000 §2Mithril Powder",
-          "§dGemstone§7: §a+5,000 §dGemstone Powder",
-          "§bGlacite§7: §a+5,000 §bGlacite Powder"
+          "§2Mithril§7: §a+{stat} §2Mithril Powder",
+          "§dGemstone§7: §a+{stat} §dGemstone Powder",
+          "§bGlacite§7: §a+{stat} §bGlacite Powder"
         ]
       },
       "anomalous_desire": {

--- a/constants/sblevels.json
+++ b/constants/sblevels.json
@@ -19,7 +19,7 @@
     "dungeon_task": 2760,
     "essence_shop_task": 1250,
     "slaying_task": 10190,
-    "skill_related_task": 5320,
+    "skill_related_task": 5883,
     "miscellaneous_task": 2281,
     "story_task": 140,
     "event_task": 625
@@ -230,8 +230,8 @@
   },
   "skill_related_task": {
     "mining": {
-      "mining": 3285,
-      "hotm": 2255,
+      "mining": 3848,
+      "hotm": 2818,
       "commission_milestone": 255,
       "potm": 1000,
       "rock_milestone": 100,


### PR DESCRIPTION
This requires an updated version of neu, so merge on release of 2.4.0

This will show as lisp-error for outdated users but i dont care