### PR TITLE
Github action to update museum data

### DIFF
--- a/.github/scripts/updateMuseum.py
+++ b/.github/scripts/updateMuseum.py
@@ -21,8 +21,7 @@ def fetchJson(apiUrl):
         response.raise_for_status()
         return response.json()
     except requests.RequestException as e:
-        print(f"Error fetching data from {apiUrl}: {e}")
-        return {}
+        raise requests.RequestException(f"Error fetching data from {apiUrl}: {e}")
 
 
 def processMuseumData(internalName, data):

--- a/.github/scripts/updateMuseum.py
+++ b/.github/scripts/updateMuseum.py
@@ -1,0 +1,141 @@
+import json
+import requests
+import os
+
+outputJson = {}
+weapons = set()
+armor = set()
+rarities = set()
+special = set()
+armorToID = {}
+children = {}
+maxValues = {}
+itemToXp = {}
+armorSets = {}
+mappedIds = {}
+
+
+def fetchJson(apiUrl):
+    try:
+        response = requests.get(apiUrl)
+        response.raise_for_status()
+        return response.json()
+    except requests.RequestException as e:
+        print(f"Error fetching data from {apiUrl}: {e}")
+        return {}
+
+
+def processMuseumData(internalName, data):
+    itemType = data.get('type')
+
+    if 'parent' in data:
+        parentData = data['parent']
+        if parentData:
+            for parent in parentData:
+                children[parentData[parent]] = parent
+
+    if 'mapped_item_ids' in data:
+        for mappedId in data['mapped_item_ids']:
+            mappedIds[mappedId] = internalName
+
+    if itemType == 'ARMOR_SETS':
+        donationXpInfo = data.get('armor_set_donation_xp', {})
+        for armorSet in donationXpInfo:
+            itemToXp[armorSet] = donationXpInfo[armorSet]
+            armor.add(armorSet)
+            addPieceToSet(internalName, armorSet)
+    else:
+        donationXp = data.get('donation_xp', 0)
+        itemToXp[internalName] = donationXp
+
+    if itemType == 'WEAPONS':
+        weapons.add(internalName)
+    elif itemType == 'RARITIES':
+        rarities.add(internalName)
+
+
+def addPieceToSet(piece, setName):
+    if setName not in armorSets:
+        armorSets[setName] = set()
+    armorSets[setName].add(piece)
+
+
+priorityExceptions = {
+    "PERFECT_TIER_12": "PERFECT_HELMET_12",
+    "PERFECT_TIER_13": "PERFECT_HELMET_13",
+    "ARMOR_OF_THE_PACK": "HELMET_OF_THE_PACK",
+    "SALMON_NEW": "SALMON_HELMET_NEW",
+}
+
+setPriorityList = [
+    "HELMET",
+    "NECKLACE",
+    "HOOD",
+    "HAT",
+    "CHESTPLATE",
+    "CLOAK",
+]
+
+
+def findAppropriateId(setName):
+    if setName in priorityExceptions:
+        armorToID[setName] = priorityExceptions[setName]
+        return
+
+    partsMap = {}
+    for part in armorSets[setName]:
+        partsMap[part] = part.split("_")[-1]
+
+    priorityMap = {part: index for index, part in enumerate(setPriorityList)}
+
+    sortedParts = sorted(partsMap.keys(), key=lambda part: priorityMap.get(partsMap[part], float('inf')))
+
+    highestPriorityPart = sortedParts[0] if sortedParts else None
+
+    if highestPriorityPart and partsMap[highestPriorityPart] not in priorityMap:
+        print(f"Highest priority part for set {setName} was not found in setPriorityList. Parts: {partsMap}")
+
+    armorToID[setName] = highestPriorityPart
+
+
+if __name__ == '__main__':
+
+    url = "https://api.hypixel.net/v2/resources/skyblock/items"
+    fetchedJson = fetchJson(url)
+    items = fetchedJson['items']
+
+    for item in items:
+        itemId = item['id']
+
+        if 'museum' in item:
+            special.add(itemId)
+
+        if 'museum_data' in item:
+            processMuseumData(itemId, item['museum_data'])
+
+    for armorSet in armorSets:
+        findAppropriateId(armorSet)
+
+    maxValues['weapons'] = len(weapons)
+    maxValues['armor'] = len(armor)
+    maxValues['rarities'] = len(rarities)
+    maxValues['special'] = 48
+    maxValues['total'] = maxValues['weapons'] + maxValues['armor'] + maxValues['rarities']
+
+    outputJson = {
+        "weapons": sorted(list(weapons), key=lambda item: (itemToXp.get(item, 0), item)),
+        "armor": sorted(list(armor), key=lambda item: (itemToXp.get(item, 0), item)),
+        "rarities": sorted(list(rarities), key=lambda item: (itemToXp.get(item, 0), item)),
+        "special": sorted(list(special)),
+        "armor_to_id": dict(sorted(armorToID.items())),
+        "children": dict(sorted(children.items())),
+        "max_values": maxValues,
+        "itemToXp": dict(sorted(itemToXp.items())),
+        "mapped_ids": dict(sorted(mappedIds.items())),
+    }
+
+    os.makedirs(os.path.dirname("constants/museum.json"), exist_ok=True)
+    with open("constants/museum.json", "w") as json_file:
+        json.dump(outputJson, json_file, indent=2)
+
+    print(f"Saved {maxValues['total']} items to museum.json")

--- a/.github/workflows/update-museum.yml
+++ b/.github/workflows/update-museum.yml
@@ -1,0 +1,47 @@
+name: Update Museum Data
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update-data:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install requests library
+        run: python -m pip install requests
+
+      - name: Run Python script
+        run: python .github/scripts/updateMuseum.py
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "github-actions@github.com"
+          git add constants/museum.json
+          if git diff-index --quiet HEAD --; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "Update museum data from Hypixel API"
+          git push --force origin HEAD:bot/museum
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: bot/museum
+          base: master
+          title: "Automated Update of Museum Data"
+          body: "This pull request contains the latest museum data sourced from the Hypixel API."
+          labels: "automated update"


### PR DESCRIPTION
This adds a github action that runs each time something is committed into master. 
When this happens it will fetch the hypixel items api and extract the relevant museum data and add it to constants/museum.json

It will then open a pull request if there are changes between the newly generated file and the current one.

This action requires these permissions to be set in the actions tab of the repo settings. Otherwise it will not create the pull request
![image](https://github.com/user-attachments/assets/c587c1d9-8a68-4eb4-bf87-ac7260e8dbc8)

Demo pull request (This was just fixing an issue in the python script, the actual change this will make the first time it is ran will be much bigger)
https://github.com/CalMWolfs/TestRepo/pull/6

The created file works for 15h's profile and shows all items as donated
![image](https://github.com/user-attachments/assets/ff9bfc82-5ed9-4453-a0dc-250ebfe300f3)

The ordering of the file is based off the rewarded skyblock exp -> alphabetical. This is similar to hypixel but i could not work out how hypixel orders it after it is done by exp. As it isnt related to alphabetical, game_stage or order it appears in the api
