### PR TITLE
Replace old wheat stuff with new wheat stuff

### DIFF
--- a/.github/workflows/update-museum.yml
+++ b/.github/workflows/update-museum.yml
@@ -9,6 +9,8 @@ jobs:
   update-data:
     runs-on: ubuntu-latest
 
+    if: ${{ github.repository_id == '247692460' }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/constants/sacks.json
+++ b/constants/sacks.json
@@ -27,8 +27,8 @@
     "Enchanted Agronomy": {
       "item": "LARGE_ENCHANTED_AGRONOMY_SACK",
       "contents": [
-        "ENCHANTED_HAY_BLOCK",
-        "TIGHTLY_TIED_HAY_BALE",
+        "ENCHANTED_WHEAT",
+        "ENCHANTED_HAY_BALE",
         "ENCHANTED_SEEDS",
         "BOX_OF_SEEDS",
         "ENCHANTED_CARROT",


### PR DESCRIPTION
Replaces the old wheats in sacks with the new wheats, i know the legacy items can still be in there but we have also removed other items such as flawless gems.

Also makes the update museum aaction only run on the neu/neu-repo 