### PR TITLE
Update OBSIDIAN_TABLET.json

### DIFF
--- a/items/OBSIDIAN_TABLET.json
+++ b/items/OBSIDIAN_TABLET.json
@@ -40,7 +40,7 @@
   "internalname": "OBSIDIAN_TABLET",
   "clickcommand": "viewrecipe",
   "modver": "2.1.0-REL",
-  "crafttext": "Requires: Obisidan XI",
+  "crafttext": "Requires: Obisidan IX",
   "infoType": "WIKI_URL",
   "info": [
     "https://hypixel-skyblock.fandom.com/wiki/Obsidian_Tablet",


### PR DESCRIPTION
Fixed a typo in the craft text.
The recipe is unlocked at `Obsidian IX`. There is no `Obsidian XI` either, it's capped at `X`.