### PR TITLE
Thunder/Storm/Hurricane Bottle Fixes

### DIFF
--- a/items/HURRICANE_IN_A_BOTTLE.json
+++ b/items/HURRICANE_IN_A_BOTTLE.json
@@ -1,0 +1,23 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§6Hurricane in a Bottle",
+  "nbttag": "{HideFlags:254,SkullOwner:{Id:\"8ef92f5f-b4c9-404a-9db9-4ee23e608a37\",hypixelPopulated:1b,Properties:{textures:[0:{Value:\"ewogICJ0aW1lc3RhbXAiIDogMTczMDY0NzM1NjM1NywKICAicHJvZmlsZUlkIiA6ICI5ZjJiY2M1M2U4YzM0OTY4YTc5Yzc0NTExYWQ2NmQyYyIsCiAgInByb2ZpbGVOYW1lIiA6ICJLYWJveWlvIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzU5ZDU4YjMxMTI2NTZiNTM5MDYzYWM3NWEzNmY2MzU5ZTI1NmYzZmNmNzU1ZjVkOGM4YzVhMDA0OTNmOTg2NTEiCiAgICB9CiAgfQp9\"}]}},display:{Lore:[0:\"§7§8Combinable in Anvil\",1:\"\",2:\"§7§7What happens if you open it? The\",3:\"§7answer may shock you.\",4:\"\",5:\"§7Charge: §e5,000,000§6/§e5,000,000\"],Name:\"§6Hurricane In A Bottle\"},ExtraAttributes:{id:\"HURRICANE_IN_A_BOTTLE\"}}",
+  "damage": 3,
+  "lore": [
+    "§7§8Combinable in Anvil",
+    "",
+    "§7§7What happens if you open it? The",
+    "§7answer may shock you.",
+    "",
+    "§7Charge: §e5,000,000§6/§e5,000,000"
+  ],
+  "internalname": "HURRICANE_IN_A_BOTTLE",
+  "crafttext": "",
+  "clickcommand": "",
+  "modver": "2.5.0",
+  "infoType": "WIKI_URL",
+  "info": [
+    "https://hypixel-skyblock.fandom.com/wiki/Hurricane_in_a_Bottle",
+    "https://wiki.hypixel.net/Hurricane_In_A_Bottle"
+  ]
+}

--- a/items/HURRICANE_IN_A_BOTTLE.json
+++ b/items/HURRICANE_IN_A_BOTTLE.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:skull",
   "displayname": "§6Hurricane in a Bottle",
-  "nbttag": "{HideFlags:254,SkullOwner:{Id:\"8ef92f5f-b4c9-404a-9db9-4ee23e608a37\",hypixelPopulated:1b,Properties:{textures:[0:{Value:\"ewogICJ0aW1lc3RhbXAiIDogMTczMDY0NzM1NjM1NywKICAicHJvZmlsZUlkIiA6ICI5ZjJiY2M1M2U4YzM0OTY4YTc5Yzc0NTExYWQ2NmQyYyIsCiAgInByb2ZpbGVOYW1lIiA6ICJLYWJveWlvIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzU5ZDU4YjMxMTI2NTZiNTM5MDYzYWM3NWEzNmY2MzU5ZTI1NmYzZmNmNzU1ZjVkOGM4YzVhMDA0OTNmOTg2NTEiCiAgICB9CiAgfQp9\"}]}},display:{Lore:[0:\"§7§8Combinable in Anvil\",1:\"\",2:\"§7§7What happens if you open it? The\",3:\"§7answer may shock you.\",4:\"\",5:\"§7Charge: §e5,000,000§6/§e5,000,000\"],Name:\"§6Hurricane In A Bottle\"},ExtraAttributes:{id:\"HURRICANE_IN_A_BOTTLE\"}}",
+  "nbttag": "{HideFlags:254,SkullOwner:{Id:\"8ef92f5f-b4c9-404a-9db9-4ee23e608a37\",hypixelPopulated:1b,Properties:{textures:[0:{Value:\"ewogICJ0aW1lc3RhbXAiIDogMTczMDY0NzM1NjM1NywKICAicHJvZmlsZUlkIiA6ICI5ZjJiY2M1M2U4YzM0OTY4YTc5Yzc0NTExYWQ2NmQyYyIsCiAgInByb2ZpbGVOYW1lIiA6ICJLYWJveWlvIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzU5ZDU4YjMxMTI2NTZiNTM5MDYzYWM3NWEzNmY2MzU5ZTI1NmYzZmNmNzU1ZjVkOGM4YzVhMDA0OTNmOTg2NTEiCiAgICB9CiAgfQp9\"}]}},display:{Lore:[0:\"§7§8Combinable in Anvil\",1:\"\",2:\"§7§7What happens if you open it? The\",3:\"§7answer may shock you.\",4:\"\",5:\"§7Charge: §e5,000,000§6/§e5,000,000\",6:\"\",7:\"§6§lLEGENDARY\"],Name:\"§6Hurricane in a Bottle\"},ExtraAttributes:{id:\"HURRICANE_IN_A_BOTTLE\"}}",
   "damage": 3,
   "lore": [
     "§7§8Combinable in Anvil",
@@ -9,7 +9,9 @@
     "§7§7What happens if you open it? The",
     "§7answer may shock you.",
     "",
-    "§7Charge: §e5,000,000§6/§e5,000,000"
+    "§7Charge: §e5,000,000§6/§e5,000,000",
+    "",
+    "§6§lLEGENDARY"
   ],
   "internalname": "HURRICANE_IN_A_BOTTLE",
   "crafttext": "",

--- a/items/STORM_IN_A_BOTTLE.json
+++ b/items/STORM_IN_A_BOTTLE.json
@@ -16,6 +16,10 @@
   "internalname": "STORM_IN_A_BOTTLE",
   "crafttext": "",
   "clickcommand": "",
-  "modver": "",
-  "infoType": ""
+  "modver": "2.5.0",
+  "infoType": "WIKI_URL",
+  "info": [
+    "https://hypixel-skyblock.fandom.com/wiki/Storm_in_a_Bottle",
+    "https://wiki.hypixel.net/Storm_In_A_Bottle"
+  ]
 }

--- a/items/THUNDER_IN_A_BOTTLE.json
+++ b/items/THUNDER_IN_A_BOTTLE.json
@@ -1,22 +1,25 @@
 {
   "itemid": "minecraft:skull",
-  "displayname": "§f§f§5Thunder in a Bottle",
-  "nbttag": "{HideFlags:254,SkullOwner:{Id:\"5f67bc23-bb55-35e6-8f01-b5534e4ecfca\",Properties:{textures:[0:{Value:\"ewogICJ0aW1lc3RhbXAiIDogMTY0MTA5ODc0MzQ2NywKICAicHJvZmlsZUlkIiA6ICIwNjNhMTc2Y2RkMTU0ODRiYjU1MjRhNjQyMGM1YjdhNCIsCiAgInByb2ZpbGVOYW1lIiA6ICJkYXZpcGF0dXJ5IiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzI0Mzc4Yjk4NmUzNTg1NTVlZTczZjA5YjIxMGQ0OWVjMTM3MTlkZTVlYTg4ZDc1NTIzNzcwZDMxMTYzZjNhZWYiLAogICAgICAibWV0YWRhdGEiIDogewogICAgICAgICJtb2RlbCIgOiAic2xpbSIKICAgICAgfQogICAgfQogIH0KfQ\u003d\u003d\"}]}},display:{Lore:[0:\"§7§8Combinable in Anvil\",1:\"\",2:\"§7§7What happens if you open it?\",3:\"§7The answer may shock you.\",4:\"\",5:\"§5§lEPIC\"],Name:\"§f§f§5Thunder in a Bottle\"},ExtraAttributes:{id:\"THUNDER_IN_A_BOTTLE\"}}",
+  "displayname": "§5Thunder in a Bottle",
+  "nbttag": "{HideFlags:254,SkullOwner:{Id:\"5f67bc23-bb55-35e6-8f01-b5534e4ecfca\",hypixelPopulated:1b,Properties:{textures:[0:{Signature:\"hhcn6WZXlDxSoEE3dYzTYIc9f5lIk0YFlpA9Z0J/UQjH6IUuvRqdHVE0FssAnvCKHFOFSOQCxfZBZIASgQKWgDiMlNS/9oYPvYScENSyJuRNDjDwdJD/sd9LlUpkpjUPSgb9vOvSEeRBzzZVE7hO4Ff1O8FbCPG1sNyZafOQ4/kzKVcW77f8L5zWlSlxW1hEOsnPRgjLd17W1q+PyH0px81mt4tLOsZhg9a9dMZMT5zrPUwGz92rIFte4cZ7LtoxcQISB8T/EPIEkM1aBoK3/hCWy/YQbGXmwo5bBAn8Vc4ah8WbnRmkVUg75wn7rmEOY4RLH7HMB89Le6bnyP/gkbrzJIm66966a6o1iNX4/SXW+mjJcPc7We/Of+gtXdizW9qZ7I7FjQUKwIxmbBuKkWviptqYAKXRiFzg+gOQTVf4P1cChcNX5oibDRKthRmMOgeuLeBC1WzTx1LpXSD/l0a8YPRPuEKrsPnKS8IfPOxTfKZwYCc6iK9PxWAwDwqUe8Co+fu9kHAqrRmzUtoO+txvrnACCtgHd4W1xoW+tYNaKzs/Zz7vuf85p4YQDDZ5FzrjEtjxFTMbskMZ5fEfNXqmoxM05TyMylbX9lX5dmedORpfd6FRDKjCO3Yg/uq9WGsz/b2pbY1vWMXbTHnWPmeJsq8vSF/rTIycObLNi7Y\u003d\",Value:\"ewogICJ0aW1lc3RhbXAiIDogMTY0MTA5ODc0MzQ2NywKICAicHJvZmlsZUlkIiA6ICIwNjNhMTc2Y2RkMTU0ODRiYjU1MjRhNjQyMGM1YjdhNCIsCiAgInByb2ZpbGVOYW1lIiA6ICJkYXZpcGF0dXJ5IiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzI0Mzc4Yjk4NmUzNTg1NTVlZTczZjA5YjIxMGQ0OWVjMTM3MTlkZTVlYTg4ZDc1NTIzNzcwZDMxMTYzZjNhZWYiLAogICAgICAibWV0YWRhdGEiIDogewogICAgICAgICJtb2RlbCIgOiAic2xpbSIKICAgICAgfQogICAgfQogIH0KfQ\u003d\u003d\"}]}},display:{Lore:[0:\"§7§8Combinable in Anvil\",1:\"\",2:\"§7§7What happens if you open it? The\",3:\"§7answer may shock you.\",4:\"\",5:\"§7Charge: §e50,000§6/§e50,000\",6:\"\",7:\"§5§lEPIC\"],Name:\"§5Thunder in a Bottle\"},ExtraAttributes:{id:\"THUNDER_IN_A_BOTTLE\"}}",
   "damage": 3,
   "lore": [
     "§7§8Combinable in Anvil",
     "",
-    "§7§7What happens if you open it?",
-    "§7The answer may shock you.",
+    "§7§7What happens if you open it? The",
+    "§7answer may shock you.",
+    "",
+    "§7Charge: §e50,000§6/§e50,000",
     "",
     "§5§lEPIC"
   ],
   "internalname": "THUNDER_IN_A_BOTTLE",
   "crafttext": "",
   "clickcommand": "",
-  "modver": "2.1.0-REL",
+  "modver": "2.5.0",
   "infoType": "WIKI_URL",
   "info": [
+    "https://hypixel-skyblock.fandom.com/wiki/Thunder_in_a_Bottle",
     "https://wiki.hypixel.net/Thunder_In_A_Bottle"
   ]
 }

--- a/items/THUNDER_IN_A_BOTTLE_EMPTY.json
+++ b/items/THUNDER_IN_A_BOTTLE_EMPTY.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:skull",
   "displayname": "§5Empty Thunder Bottle",
-  "nbttag": "{HideFlags:254,SkullOwner:{Id:\"e4ef477e-85b5-35db-86f6-373c83317986\",Properties:{textures:[0:{Value:\"ewogICJ0aW1lc3RhbXAiIDogMTY0MTI0Mjc1NzEwMCwKICAicHJvZmlsZUlkIiA6ICJiNzVjZDRmMThkZjg0MmNlYjJhY2MxNTU5MTNiMjA0YiIsCiAgInByb2ZpbGVOYW1lIiA6ICJLcmlzdGlqb25hczEzIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzU3YTZkMzVlOWQ0MzU0MmQyNzUwYzQ4MzZiNDAzN2Y3NTE0NmViMjc4NzUzMmI0YzRjNWMzYjI2YmI2M2RjMTAiLAogICAgICAibWV0YWRhdGEiIDogewogICAgICAgICJtb2RlbCIgOiAic2xpbSIKICAgICAgfQogICAgfQogIH0KfQ\u003d\u003d\"}]}},display:{Lore:[0:\"§7This bottle is empty, I wonder if\",1:\"§7there is a way to charge it up...\",2:\"\",3:\"§7Charge: §e0§6/§e50,000\",4:\"\",5:\"§5§lEPIC\"],Name:\"§5Empty Thunder Bottle\"},ExtraAttributes:{id:\"THUNDER_IN_A_BOTTLE_EMPTY\"}}",
+  "nbttag": "{HideFlags:254,SkullOwner:{Id:\"e4ef477e-85b5-35db-86f6-373c83317986\",hypixelPopulated:1b,Properties:{textures:[0:{Signature:\"AUdos2BUxp3C6tuXHtsso8mWxgTZBmOl3p1ZrBLj3NhL8fjz0iLWZYXl0ufZITPNH9C8gIVP6ypAXCIB4H8Vn6R30pb1JBbP8LnA0A3bS7HCPhneE34KsTqDoZYm1JOOypdj8256AuYnJbzzWgnESids5OmJSBh4ixIF23+p/5pmrsj81dRTrdH08BFDk8QRqr6R3JwtuGQQbiLnqLGI/K+dqLlzhjNLGp9qCUfaErTBUJqvexiRAoDaG9IcT1JIIPumdSmUiu+Rb7xzxtHHkdGr7/IAD8hXhn93PsGPjfbrmNY0UvQJTOT2wPHd7DWo1mRCwEJscDK92udOjS/r/qg6Vir07dc6okygSpzBjhPY0BRcSr1MevAL+pabP9kULrp9vUGl+dG4dbINsVRW2cqIQzS1LmVtgtpKhnGZRkwRjerORa+sIpCfg2FCGQh9kR97WSofdZEhOFF1J600GJ30fr2SHlmSR0k9ONPIouqR34KPNb/Csm28lV9He+PkO7N7uUqZri5aM5CXDRlDZJAiH8EHMoDBSQgK4OAhM6YNyl6UupqFAQgw/3I9AjBhY/5TZqx2q8ZyDNHH2HYuxyMOlKz5SCnrkREtDjLsvlChkNHB9tEbUQre5Mer6mSL2DQamUN8U8Rr1FF0y0DhGkB9+u31SUGmE0j+REVg0H4\u003d\",Value:\"ewogICJ0aW1lc3RhbXAiIDogMTY0MTI0Mjc1NzEwMCwKICAicHJvZmlsZUlkIiA6ICJiNzVjZDRmMThkZjg0MmNlYjJhY2MxNTU5MTNiMjA0YiIsCiAgInByb2ZpbGVOYW1lIiA6ICJLcmlzdGlqb25hczEzIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzU3YTZkMzVlOWQ0MzU0MmQyNzUwYzQ4MzZiNDAzN2Y3NTE0NmViMjc4NzUzMmI0YzRjNWMzYjI2YmI2M2RjMTAiLAogICAgICAibWV0YWRhdGEiIDogewogICAgICAgICJtb2RlbCIgOiAic2xpbSIKICAgICAgfQogICAgfQogIH0KfQ\u003d\u003d\"}]}},display:{Lore:[0:\"§7This bottle is empty, I wonder if\",1:\"§7there is a way to charge it up...\",2:\"\",3:\"§7Charge: §e0§6/§e50,000\",4:\"\",5:\"§5§lEPIC\"],Name:\"§5Empty Thunder Bottle\"},ExtraAttributes:{id:\"THUNDER_IN_A_BOTTLE_EMPTY\"}}",
   "damage": 3,
   "lore": [
     "§7This bottle is empty, I wonder if",
@@ -25,7 +25,7 @@
   "internalname": "THUNDER_IN_A_BOTTLE_EMPTY",
   "crafttext": "",
   "clickcommand": "viewrecipe",
-  "modver": "2.1.1-PRE",
+  "modver": "2.5.0",
   "infoType": "WIKI_URL",
   "info": [
     "https://hypixel-skyblock.fandom.com/wiki/Empty_Thunder_Bottle",


### PR DESCRIPTION
Updated Thunder/Storm/Hurricane Bottle lores, and added Hurricane in a Bottle.

Since I haven't found an actual Hurricane in a Bottle to copy the data off, I got info off the official wiki, and used a random UUID for the SkullOwner for now to satisfy Minecraft. The chance of a UUID collision here is about 1 in 600 octillion, so we should be fine. It can be updated later once we get the actual item.