### PR TITLE
Remove Ancient Rose from Sadan drops

### DIFF
--- a/items/SADAN_BOSS.json
+++ b/items/SADAN_BOSS.json
@@ -30,11 +30,6 @@
       "type": "drops",
       "drops": [
         {
-          "id": "GOLEM_POPPY",
-          "chance": "10.32%",
-          "extra": ["§e§lChest Price: §62,000,000 coins"]
-        },
-        {
           "id": "GIANT_TOOTH",
           "chance": "3.4%",
           "extra": ["§e§lChest Price: §62,000,000 coins"]
@@ -94,13 +89,6 @@
       "panorama": "dungeon",
       "type": "drops",
       "drops": [
-        {
-          "id": "GOLEM_POPPY",
-          "chance": "10.83%",
-          "extra": [
-            "§e§lChest Price: §62,000,000 coins"
-          ]
-        },
         {
           "id": "GIANT_TOOTH",
           "chance": "3.8%",


### PR DESCRIPTION
Was removed from chests in September 2023: https://wiki.hypixel.net/Ancient_Rose#History

Didn't bother adjusting the drop rates of the other items for now, because the official wiki is also partially outdated on this right now and I don't feel like calculating it myself.