### PR TITLE
feat: Forest Crystal

### DIFF
--- a/items/FOREST_ISLAND_CRYSTAL.json
+++ b/items/FOREST_ISLAND_CRYSTAL.json
@@ -1,0 +1,20 @@
+{
+  "itemid": "minecraft:skull",
+  "displayname": "§9Forest Crystal",
+  "nbttag": "{HideFlags:254,SkullOwner:{Id:\"7a237e5c-ca9a-3dc1-b1d9-b385fc200aa7\",Properties:{textures:[0:{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTI2NWY5NmY1NGI3ODg4NWM0NmU3ZDJmODZiMWMxZGJmZTY0M2M2MDYwZmM3ZmNjOTgzNGMzZTNmZDU5NTEzNSJ9fX0\u003d\"}]}},display:{Lore:[0:\"§7\",1:\"\",2:\"§7Effective Radius: §b20\"],Name:\"§9Forest Crystal\"},ExtraAttributes:{id:\"FOREST_ISLAND_CRYSTAL\"}}",
+  "damage": 3,
+  "lore": [
+    "§7",
+    "",
+    "§7Effective Radius: §b20"
+  ],
+  "internalname": "FOREST_ISLAND_CRYSTAL",
+  "crafttext": "",
+  "clickcommand": "",
+  "modver": "",
+  "infoType": "WIKI_URL",
+  "info": [
+    "https://hypixel-skyblock.fandom.com/wiki/Bat_Crystal",
+    "https://wiki.hypixel.net/Bat_Crystal"
+  ]
+}


### PR DESCRIPTION
_Forest Crystals_, commonly referred to as _Bat Crystals_, are the floating cubes above roofed forest items. Unlike other crystals, this one cannot be picked up, but it still has an item form in the API, and can still be obtained in-game in its placed form.