### PR TITLE
Update MAGMA_CUBE_HEAD

### DIFF
--- a/items/MAGMA_CUBE_HEAD.json
+++ b/items/MAGMA_CUBE_HEAD.json
@@ -10,24 +10,13 @@
     "§7§8This item can be reforged!",
     "§f§lCOMMON HELMET"
   ],
-  "recipe": {
-    "A1": "MAGMA_CREAM:1",
-    "A2": "MAGMA_CREAM:1",
-    "A3": "MAGMA_CREAM:1",
-    "B1": "MAGMA_CREAM:1",
-    "B2": "",
-    "B3": "MAGMA_CREAM:1",
-    "C1": "MAGMA_CREAM:1",
-    "C2": "MAGMA_CREAM:1",
-    "C3": "MAGMA_CREAM:1"
-  },
   "internalname": "MAGMA_CUBE_HEAD",
-  "clickcommand": "viewrecipe",
+  "clickcommand": "",
   "modver": "2.1.0-REL",
   "infoType": "WIKI_URL",
   "info": [
     "https://hypixel-skyblock.fandom.com/wiki/Magma_Cube_Head",
     "https://wiki.hypixel.net/Magma_Cube_Head"
   ],
-  "crafttext": "Requires: Magma Cream II"
+  "crafttext": ""
 }


### PR DESCRIPTION
Removed Magma Cube Head recipe as it's no longer craftable since Crimson Isle release.
https://wiki.hypixel.net/Magma_Cube_Head