### PR TITLE
fix: Remove trailing section sign in lore

### DIFF
--- a/items/MINER_SKELETON_MONSTER.json
+++ b/items/MINER_SKELETON_MONSTER.json
@@ -1,11 +1,11 @@
 {
   "itemid": "minecraft:skull",
   "displayname": "§9Miner Skeleton (Monster)",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§7These skeletons have crafted\",1:\"§7gear from the diamonds around§\",2:\"§7them - resulting in a look both\",3:\"§7fashionable and protective.\",4:\"\",5:\"§c❤ Health§8: §c250 - 300\"],Name:\"§9Miner Skeleton (Monster)\"},ExtraAttributes:{id:\"MINER_SKELETON_MONSTER\"}}",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§7These skeletons have crafted\",1:\"§7gear from the diamonds around\",2:\"§7them - resulting in a look both\",3:\"§7fashionable and protective.\",4:\"\",5:\"§c❤ Health§8: §c250 - 300\"],Name:\"§9Miner Skeleton (Monster)\"},ExtraAttributes:{id:\"MINER_SKELETON_MONSTER\"}}",
   "damage": 0,
   "lore": [
     "§7These skeletons have crafted",
-    "§7gear from the diamonds around§",
+    "§7gear from the diamonds around",
     "§7them - resulting in a look both",
     "§7fashionable and protective.",
     "",


### PR DESCRIPTION
Fixed a trailing formatting code in the lore of the Skeleton Miner 