### PR TITLE
fix: Remove soulbound from remaining attribute shards

### DIFF
--- a/items/ATTRIBUTE_SHARD_DOMINANCE;4.json
+++ b/items/ATTRIBUTE_SHARD_DOMINANCE;4.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:prismarine_shard",
   "displayname": "§fAttribute Shard",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§bDominance IV\",1:\"§7Gain §c+6% §7damage when at full health.\",2:\"\",3:\"§7Combine with items in the §bAttribute\",4:\"§bFusion §7menu to apply attributes.\",5:\"\",6:\"§8§l* §8Co-op Soulbound §8§l*\",7:\"§f§lCOMMON\"],Name:\"§fAttribute Shard\"},ExtraAttributes:{attributes:{dominance:4},id:\"ATTRIBUTE_SHARD_DOMINANCE;4\"}}",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§bDominance IV\",1:\"§7Gain §c+6% §7damage when at full health.\",2:\"\",3:\"§7Combine with items in the §bAttribute\",4:\"§bFusion §7menu to apply attributes.\",5:\"\",6:\"§f§lCOMMON\"],Name:\"§fAttribute Shard\"},ExtraAttributes:{attributes:{dominance:4},id:\"ATTRIBUTE_SHARD_DOMINANCE;4\"}}",
   "damage": 0,
   "lore": [
     "§bDominance IV",

--- a/items/ATTRIBUTE_SHARD_DOMINANCE;4.json
+++ b/items/ATTRIBUTE_SHARD_DOMINANCE;4.json
@@ -10,7 +10,6 @@
     "§7Combine with items in the §bAttribute",
     "§bFusion §7menu to apply attributes.",
     "",
-    "§8§l* §8Co-op Soulbound §8§l*",
     "§f§lCOMMON"
   ],
   "internalname": "ATTRIBUTE_SHARD_DOMINANCE;4",

--- a/items/ATTRIBUTE_SHARD_LIFELINE;4.json
+++ b/items/ATTRIBUTE_SHARD_LIFELINE;4.json
@@ -12,7 +12,6 @@
     "§7Combine with items in the §bAttribute",
     "§bFusion §7menu to apply attributes.",
     "",
-    "§8§l* §8Co-op Soulbound §8§l*",
     "§f§lCOMMON"
   ],
   "internalname": "ATTRIBUTE_SHARD_LIFELINE;4",

--- a/items/ATTRIBUTE_SHARD_LIFELINE;4.json
+++ b/items/ATTRIBUTE_SHARD_LIFELINE;4.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:prismarine_shard",
   "displayname": "§fAttribute Shard",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§bLifeline IV\",1:\"§7When under §c20% §7maximum HP, your §c❁\",2:\"§cDamage §7and §a❈ Defense §7increase by\",3:\"§7§a10%§7.\",4:\"\",5:\"§7Combine with items in the §bAttribute\",6:\"§bFusion §7menu to apply attributes.\",7:\"\",8:\"§8§l* §8Co-op Soulbound §8§l*\",9:\"§f§lCOMMON\"],Name:\"§fAttribute Shard\"},ExtraAttributes:{attributes:{lifeline:4},id:\"ATTRIBUTE_SHARD_LIFELINE;4\"}}",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§bLifeline IV\",1:\"§7When under §c20% §7maximum HP, your §c❁\",2:\"§cDamage §7and §a❈ Defense §7increase by\",3:\"§7§a10%§7.\",4:\"\",5:\"§7Combine with items in the §bAttribute\",6:\"§bFusion §7menu to apply attributes.\",7:\"\",8:\"§f§lCOMMON\"],Name:\"§fAttribute Shard\"},ExtraAttributes:{attributes:{lifeline:4},id:\"ATTRIBUTE_SHARD_LIFELINE;4\"}}",
   "damage": 0,
   "lore": [
     "§bLifeline IV",

--- a/items/ATTRIBUTE_SHARD_MANA_POOL;4.json
+++ b/items/ATTRIBUTE_SHARD_MANA_POOL;4.json
@@ -11,7 +11,6 @@
     "§7§bAttribute Fusion §7menu to",
     "§7apply attributes.",
     "",
-    "§8§l* §8Co-op Soulbound §8§l*",
     "§f§lCOMMON"
   ],
   "internalname": "ATTRIBUTE_SHARD_MANA_POOL;4",

--- a/items/ATTRIBUTE_SHARD_MANA_POOL;4.json
+++ b/items/ATTRIBUTE_SHARD_MANA_POOL;4.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:prismarine_shard",
   "displayname": "§fAttribute Shard",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§bMana Pool IV\",1:\"§7Grants §b+80✎ Intelligence§7.\",2:\"\",3:\"§7Combine with items in the\",4:\"§7§bAttribute Fusion §7menu to\",5:\"§7apply attributes.\",6:\"\",7:\"§8§l* §8Co-op Soulbound §8§l*\",8:\"§f§lCOMMON\"],Name:\"§fAttribute Shard\"},ExtraAttributes:{attributes:{mana_pool:4},id:\"ATTRIBUTE_SHARD_MANA_POOL;4\"}}",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§bMana Pool IV\",1:\"§7Grants §b+80✎ Intelligence§7.\",2:\"\",3:\"§7Combine with items in the\",4:\"§7§bAttribute Fusion §7menu to\",5:\"§7apply attributes.\",6:\"\",7:\"§f§lCOMMON\"],Name:\"§fAttribute Shard\"},ExtraAttributes:{attributes:{mana_pool:4},id:\"ATTRIBUTE_SHARD_MANA_POOL;4\"}}",
   "damage": 0,
   "lore": [
     "§bMana Pool IV",


### PR DESCRIPTION
Some attribute shards still have the soulbound tag even though they aren't soulbound anymore.