### PR TITLE
fix: Replace staff ranks with a unified rank

### DIFF
--- a/constants/misc.json
+++ b/constants/misc.json
@@ -2860,33 +2860,10 @@
     "f6a600540f6b414cbe50de3c09fddad7"
   ],
   "ranks": {
-    "OWNER": {
+    "STAFF": {
       "color": "c",
-      "tag": "OWNER"
-    },
-    "ADMIN": {
-      "color": "c",
-      "tag": "ADMIN"
-    },
-    "BUILD TEAM": {
-      "color": "3",
-      "tag": "BUILD TEAM"
-    },
-    "MODERATOR": {
-      "color": "2",
-      "tag": "MOD"
-    },
-    "GAME_MASTER": {
-      "color": "2",
-      "tag": "GM"
-    },
-    "HELPER": {
-      "color": "9",
-      "tag": "HELPER"
-    },
-    "JR HELPER": {
-      "color": "9",
-      "tag": "JR HELPER"
+      "tagColor": "6",
+      "tag": "ዞ"
     },
     "YOUTUBER": {
       "color": "c",


### PR DESCRIPTION
[https://hypixel.net/threads/team-update-one-unified-rank.5628609/](https://hypixel.net/threads/team-update-one-unified-rank.5628609/)

[https://support.hypixel.net/hc/en-us/articles/360019646559-How-to-Obtain-the-Available-Ranks-on-Hypixel](https://support.hypixel.net/hc/en-us/articles/360019646559-How-to-Obtain-the-Available-Ranks-on-Hypixel)