### PR TITLE
Update Max Souls Fairy Souls Value

### DIFF
--- a/constants/fairy_souls.json
+++ b/constants/fairy_souls.json
@@ -1,6 +1,6 @@
 {
   "//": "If you would like to contribute to this list please ensure that you: take the coordinates of the soul its self and not where you stand.",
-  "Max Souls": 247,
+  "Max Souls": 253,
   "hub": [
     "138,66,129",
     "169,60,129",


### PR DESCRIPTION
Not sure if NEU itself depends on this value, but dungeon trivia in the [Skyblocker mod does](https://github.com/SkyblockerMod/Skyblocker/blob/master/src/main/java/de/hysky/skyblocker/skyblock/waypoint/FairySouls.java#L74), used for Ouro trivia.