### PR TITLE
FIX: Refined Umber recipe input number format

### DIFF
--- a/items/REFINED_UMBER.json
+++ b/items/REFINED_UMBER.json
@@ -17,7 +17,7 @@
     {
       "type": "forge",
       "inputs": [
-        "ENCHANTED_UMBER:160.0"
+        "ENCHANTED_UMBER:160"
       ],
       "count": 1.0,
       "overrideOutputId": "REFINED_UMBER",


### PR DESCRIPTION
Fixed recipe input format being float instead of int