### PR TITLE
Fix item names

### DIFF
--- a/items/ACACIA_STAIRS.json
+++ b/items/ACACIA_STAIRS.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:acacia_stairs",
-  "displayname": "§fAcacia Wood Stairs",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fAcacia Wood Stairs\"},ExtraAttributes:{id:\"ACACIA_STAIRS\"}}",
+  "displayname": "§fAcacia Stairs",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fAcacia Stairs\"},ExtraAttributes:{id:\"ACACIA_STAIRS\"}}",
   "damage": 0,
   "lore": [
     "§f§lCOMMON"

--- a/items/BIRCH_WOOD_STAIRS.json
+++ b/items/BIRCH_WOOD_STAIRS.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:birch_stairs",
-  "displayname": "§fBirch Wood Stairs",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fBirch Wood Stairs\"},ExtraAttributes:{id:\"BIRCH_WOOD_STAIRS\"}}",
+  "displayname": "§fBirch Stairs",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fBirch Stairs\"},ExtraAttributes:{id:\"BIRCH_WOOD_STAIRS\"}}",
   "damage": 0,
   "lore": [
     "§f§lCOMMON"

--- a/items/DARK_OAK_STAIRS.json
+++ b/items/DARK_OAK_STAIRS.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:dark_oak_stairs",
-  "displayname": "§fDark Oak Wood Stairs",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fDark Oak Wood Stairs\"},ExtraAttributes:{id:\"DARK_OAK_STAIRS\"}}",
+  "displayname": "§fDark Oak Stairs",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fDark Oak Stairs\"},ExtraAttributes:{id:\"DARK_OAK_STAIRS\"}}",
   "damage": 0,
   "lore": [
     "§f§lCOMMON"

--- a/items/GRASS.json
+++ b/items/GRASS.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:grass",
-  "displayname": "§fGrass Block",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fGrass Block\"},ExtraAttributes:{id:\"GRASS\"}}",
+  "displayname": "§fGrass",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fGrass\"},ExtraAttributes:{id:\"GRASS\"}}",
   "damage": 0,
   "lore": [
     "§f§lCOMMON"

--- a/items/JUNGLE_WOOD_STAIRS.json
+++ b/items/JUNGLE_WOOD_STAIRS.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:jungle_stairs",
-  "displayname": "§fJungle Wood Stairs",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fJungle Wood Stairs\"},ExtraAttributes:{id:\"JUNGLE_WOOD_STAIRS\"}}",
+  "displayname": "§fJungle Stairs",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fJungle Stairs\"},ExtraAttributes:{id:\"JUNGLE_WOOD_STAIRS\"}}",
   "damage": 0,
   "lore": [
     "§f§lCOMMON"

--- a/items/SPRUCE_WOOD_STAIRS.json
+++ b/items/SPRUCE_WOOD_STAIRS.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:spruce_stairs",
-  "displayname": "§fSpruce Wood Stairs",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fSpruce Wood Stairs\"},ExtraAttributes:{id:\"SPRUCE_WOOD_STAIRS\"}}",
+  "displayname": "§fSpruce Stairs",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fSpruce Stairs\"},ExtraAttributes:{id:\"SPRUCE_WOOD_STAIRS\"}}",
   "damage": 0,
   "lore": [
     "§f§lCOMMON"

--- a/items/STONE_BUTTON.json
+++ b/items/STONE_BUTTON.json
@@ -1,6 +1,6 @@
 {
   "itemid": "minecraft:stone_button",
-  "displayname": "§fButton",
+  "displayname": "§fStone Button",
   "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fButton\"},ExtraAttributes:{id:\"STONE_BUTTON\"}}",
   "damage": 0,
   "lore": [

--- a/items/STONE_BUTTON.json
+++ b/items/STONE_BUTTON.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:stone_button",
   "displayname": "§fStone Button",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fButton\"},ExtraAttributes:{id:\"STONE_BUTTON\"}}",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fStone Button\"},ExtraAttributes:{id:\"STONE_BUTTON\"}}",
   "damage": 0,
   "lore": [
     "§f§lCOMMON"

--- a/items/WOOD-1.json
+++ b/items/WOOD-1.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:planks",
-  "displayname": "§fSpruce Wood Planks",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fSpruce Wood Planks\"},ExtraAttributes:{id:\"WOOD-1\"}}",
+  "displayname": "§fSpruce Planks",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fSpruce Planks\"},ExtraAttributes:{id:\"WOOD-1\"}}",
   "damage": 1,
   "lore": [
     "§f§lCOMMON"

--- a/items/WOOD-2.json
+++ b/items/WOOD-2.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:planks",
-  "displayname": "§fBirch Wood Planks",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fBirch Wood Planks\"},ExtraAttributes:{id:\"WOOD-2\"}}",
+  "displayname": "§fBirch Planks",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fBirch Planks\"},ExtraAttributes:{id:\"WOOD-2\"}}",
   "damage": 2,
   "lore": [
     "§f§lCOMMON"

--- a/items/WOOD-3.json
+++ b/items/WOOD-3.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:planks",
-  "displayname": "§fJungle Wood Planks",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fJungle Wood Planks\"},ExtraAttributes:{id:\"WOOD-3\"}}",
+  "displayname": "§fJungle Planks",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fJungle Planks\"},ExtraAttributes:{id:\"WOOD-3\"}}",
   "damage": 3,
   "lore": [
     "§f§lCOMMON"

--- a/items/WOOD-4.json
+++ b/items/WOOD-4.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:planks",
-  "displayname": "§fAcacia Wood Planks",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fAcacia Wood Planks\"},ExtraAttributes:{id:\"WOOD-4\"}}",
+  "displayname": "§fAcacia Planks",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fAcacia Planks\"},ExtraAttributes:{id:\"WOOD-4\"}}",
   "damage": 4,
   "lore": [
     "§f§lCOMMON"

--- a/items/WOOD-5.json
+++ b/items/WOOD-5.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:planks",
-  "displayname": "§fDark Oak Wood Planks",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fDark Oak Wood Planks\"},ExtraAttributes:{id:\"WOOD-5\"}}",
+  "displayname": "§fDark Oak Planks",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fDark Oak Planks\"},ExtraAttributes:{id:\"WOOD-5\"}}",
   "damage": 5,
   "lore": [
     "§f§lCOMMON"

--- a/items/WOOD.json
+++ b/items/WOOD.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:planks",
-  "displayname": "§fOak Wood Planks",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fOak Wood Planks\"},ExtraAttributes:{id:\"WOOD\"}}",
+  "displayname": "§fOak Planks",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fOak Planks\"},ExtraAttributes:{id:\"WOOD\"}}",
   "damage": 0,
   "lore": [
     "§f§lCOMMON"

--- a/items/WOOD_STAIRS.json
+++ b/items/WOOD_STAIRS.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:oak_stairs",
-  "displayname": "§fOak Wood Stairs",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fOak Wood Stairs\"},ExtraAttributes:{id:\"WOOD_STAIRS\"}}",
+  "displayname": "§fOak Stairs",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fOak Stairs\"},ExtraAttributes:{id:\"WOOD_STAIRS\"}}",
   "damage": 0,
   "lore": [
     "§f§lCOMMON"

--- a/items/WOOD_STEP-1.json
+++ b/items/WOOD_STEP-1.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:wooden_slab",
-  "displayname": "§fSpruce Wood Slab",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fSpruce Wood Slab\"},ExtraAttributes:{id:\"WOOD_STEP-1\"}}",
+  "displayname": "§fSpruce Slab",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fSpruce Slab\"},ExtraAttributes:{id:\"WOOD_STEP-1\"}}",
   "damage": 1,
   "lore": [
     "§f§lCOMMON"

--- a/items/WOOD_STEP-2.json
+++ b/items/WOOD_STEP-2.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:wooden_slab",
-  "displayname": "§fBirch Wood Slab",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fBirch Wood Slab\"},ExtraAttributes:{id:\"WOOD_STEP-2\"}}",
+  "displayname": "§fBirch Slab",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fBirch Slab\"},ExtraAttributes:{id:\"WOOD_STEP-2\"}}",
   "damage": 2,
   "lore": [
     "§f§lCOMMON"

--- a/items/WOOD_STEP-3.json
+++ b/items/WOOD_STEP-3.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:wooden_slab",
-  "displayname": "§fJungle Wood Slab",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fJungle Wood Slab\"},ExtraAttributes:{id:\"WOOD_STEP-3\"}}",
+  "displayname": "§fJungle Slab",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fJungle Slab\"},ExtraAttributes:{id:\"WOOD_STEP-3\"}}",
   "damage": 3,
   "lore": [
     "§f§lCOMMON"

--- a/items/WOOD_STEP-4.json
+++ b/items/WOOD_STEP-4.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:wooden_slab",
-  "displayname": "§fAcacia Wood Slab",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fAcacia Wood Slab\"},ExtraAttributes:{id:\"WOOD_STEP-4\"}}",
+  "displayname": "§fAcacia Slab",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fAcacia Slab\"},ExtraAttributes:{id:\"WOOD_STEP-4\"}}",
   "damage": 4,
   "lore": [
     "§f§lCOMMON"

--- a/items/WOOD_STEP-5.json
+++ b/items/WOOD_STEP-5.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:wooden_slab",
-  "displayname": "§fDark Oak Wood Slab",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fDark Oak Wood Slab\"},ExtraAttributes:{id:\"WOOD_STEP-5\"}}",
+  "displayname": "§fDark Oak Slab",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fDark Oak Slab\"},ExtraAttributes:{id:\"WOOD_STEP-5\"}}",
   "damage": 5,
   "lore": [
     "§f§lCOMMON"

--- a/items/WOOD_STEP.json
+++ b/items/WOOD_STEP.json
@@ -1,7 +1,7 @@
 {
   "itemid": "minecraft:wooden_slab",
-  "displayname": "§fOak Wood Slab",
-  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fOak Wood Slab\"},ExtraAttributes:{id:\"WOOD_STEP\"}}",
+  "displayname": "§fOak Slab",
+  "nbttag": "{HideFlags:254,display:{Lore:[0:\"§f§lCOMMON\"],Name:\"§fOak Slab\"},ExtraAttributes:{id:\"WOOD_STEP\"}}",
   "damage": 0,
   "lore": [
     "§f§lCOMMON"


### PR DESCRIPTION
Some item names do not match their names in SkyBlock. I've made several patches.