### PR TITLE
fix: Correct typos in shard attributes

### DIFF
--- a/constants/attribute_shards.json
+++ b/constants/attribute_shards.json
@@ -566,7 +566,7 @@
           {
             "type": "family",
             "value": [
-              "shulker"
+              "Shulker"
             ],
             "amount": 5
           }
@@ -908,7 +908,7 @@
           },
           {
             "type": "alignment",
-            "value": "FOREST",
+            "value": "Forest",
             "amount": 5
           }
         ],
@@ -2454,7 +2454,7 @@
           {
             "type": "family",
             "value": [
-              "bird"
+              "Bird"
             ],
             "amount": 5
           },
@@ -3301,7 +3301,7 @@
           {
             "type": "family",
             "value": [
-              "bird"
+              "Bird"
             ],
             "amount": 5
           },


### PR DESCRIPTION
This pull request corrects various typos in the shard attributes to ensure consistency in casing.

Changes made:
- Changed "shulker" to "Shulker"
- Changed "bird" to "Bird"
- Changed "FOREST" to "Forest"