### PR TITLE
fix: attribute shard discrepancies

### DIFF
--- a/constants/attribute_shards.json
+++ b/constants/attribute_shards.json
@@ -401,7 +401,10 @@
       "internalName": "ATTRIBUTE_SHARD_BERRY_MOGUL;1",
       "abilityName": "Berry Mogul",
       "alignment": "Water",
-      "family": [],
+      "family": [
+        "Amphibian",
+        "Frog"
+      ],
       "fusion": {
         "components": [
           {
@@ -690,7 +693,9 @@
       "internalName": "ATTRIBUTE_SHARD_COOKIE_EATER;1",
       "abilityName": "Cookie Eater",
       "alignment": "Forest",
-      "family": []
+      "family": [
+        "Bug"
+      ]
     },
     {
       "bazaarName": "SHARD_INFERNO_KOI",
@@ -736,7 +741,9 @@
       "internalName": "ATTRIBUTE_SHARD_CRYSTAL_SERENDIPITY;1",
       "abilityName": "Crystal Serendipity",
       "alignment": "Water",
-      "family": []
+      "family": [
+        "Treasure Fish"
+      ]
     },
     {
       "bazaarName": "SHARD_SKELETOR",
@@ -860,7 +867,9 @@
       "internalName": "ATTRIBUTE_SHARD_DWARVEN_SERENDIPITY;1",
       "abilityName": "Dwarven Serendipity",
       "alignment": "Water",
-      "family": []
+      "family": [
+        "Treasure Fish"
+      ]
     },
     {
       "bazaarName": "SHARD_TERRA",
@@ -959,6 +968,7 @@
       "abilityName": "Echo of Echoes",
       "alignment": "Combat",
       "family": [
+        "Croco",
         "Reptile"
       ],
       "fusion": {
@@ -1233,7 +1243,9 @@
       "internalName": "ATTRIBUTE_SHARD_EXPERIENCE;1",
       "abilityName": "Experience",
       "alignment": "Combat",
-      "family": []
+      "family": [
+        "Lapis"
+      ]
     },
     {
       "bazaarName": "SHARD_LUMISQUID",
@@ -2436,7 +2448,7 @@
     {
       "bazaarName": "SHARD_PEST",
       "displayName": "Pest",
-      "rarity": "RARE",
+      "rarity": "UNCOMMON",
       "internalName": "ATTRIBUTE_SHARD_PEST_LUCK;1",
       "abilityName": "Pest Luck",
       "alignment": "Forest",
@@ -2580,12 +2592,12 @@
     {
       "bazaarName": "SHARD_DODO",
       "displayName": "Dodo",
-      "rarity": "RARE",
+      "rarity": "LEGENDARY",
       "internalName": "ATTRIBUTE_SHARD_RARE_BIRD;1",
       "abilityName": "Rare Bird",
       "alignment": "Forest",
       "family": [
-        "Bug"
+        "Bird"
       ],
       "fusion": {
         "components": [
@@ -2632,7 +2644,9 @@
       "internalName": "ATTRIBUTE_SHARD_ROTTEN_PICKAXE;1",
       "abilityName": "Rotten Pickaxe",
       "alignment": "Combat",
-      "family": []
+      "family": [
+        "Cave Dweller"
+      ]
     },
     {
       "bazaarName": "SHARD_HIDEONSACK",


### PR DESCRIPTION
Only verified `displayName`, `rarity`, and `family` for now with the data I had.