### PR TITLE
Fix GREAT_SPOOK_CHESTPLATE.snbt

### DIFF
--- a/itemsOverlay/4325/GREAT_SPOOK_CHESTPLATE.snbt
+++ b/itemsOverlay/4325/GREAT_SPOOK_CHESTPLATE.snbt
@@ -3,7 +3,6 @@
 		"minecraft:custom_data": {
 			color: "158:0:178",
 			edition: 3065,
-			enchantments: {
 			id: "GREAT_SPOOK_CHESTPLATE",
 			originTag: "UNKNOWN"
 		},


### PR DESCRIPTION
Item SNBT had an unclosed bracket, resulting in this error:
```
[22:24:11] [ForkJoinPool.commonPool-worker-14/ERROR]: [Skyblocker Stack Overlays] Failed to apply stack overlay! Item: GREAT_SPOOK_CHESTPLATE
com.mojang.brigadier.exceptions.CommandSyntaxException: Expected literal , at position 819: ...6602"
```