### PR TITLE
fix: added missing items to sacks

### DIFF
--- a/constants/sacks.json
+++ b/constants/sacks.json
@@ -89,7 +89,8 @@
         "ENCHANTED_COOKED_MUTTON",
         "ENCHANTED_RABBIT",
         "ENCHANTED_RABBIT_HIDE",
-        "ENCHANTED_RABBIT_FOOT"
+        "ENCHANTED_RABBIT_FOOT",
+        "ENCHANTED_COOKED_RABBIT"
       ]
     },
     "Mining": {
@@ -303,7 +304,8 @@
         "OLD_LEATHER_BOOT",
         "RUSTY_COIN",
         "TORN_CLOTH",
-        "ALLIGATOR_SKIN"
+        "ALLIGATOR_SKIN",
+        "DIVER_FRAGMENT"
       ]
     },
     "Enchanted Fishing": {
@@ -389,7 +391,8 @@
         "MAGMAG",
         "LUMINO_FIBER",
         "TENTACLE_MEAT",
-        "SULPHURIC_COAL"
+        "SULPHURIC_COAL",
+        "BLAZE_ROD"
       ]
     },
     "Crystal Hollows": {
@@ -451,7 +454,8 @@
         "BIOFUEL",
         "OIL_BARREL",
         "UMBER_KEY",
-        "TUNGSTEN_KEY"
+        "TUNGSTEN_KEY",
+        "SUSPICIOUS_SCRAP"
       ]
     },
     "Slayer": {
@@ -473,7 +477,8 @@
         "CRUDE_GABAGOOL_DISTILLATE",
         "GLOWSTONE_DUST_DISTILLATE",
         "MAGMA_CREAM_DISTILLATE",
-        "NETHER_STALK_DISTILLATE"
+        "NETHER_STALK_DISTILLATE",
+        "TARANTULA_CATALYST"
       ]
     },
     "Spooky": {


### PR DESCRIPTION
Items:
* ench. cooked rabbit
* diver fragment
* blaze rod (added to nether sack, present in combat sack)
* suspicious scrap
* tarantula catalyst