### PR TITLE
Abiphone Call Names

### DIFF
--- a/constants/abiphone.json
+++ b/constants/abiphone.json
@@ -140,9 +140,6 @@
     "z": -88
   },
   "Fear Mongerer": {
-    "callNames": [
-      "fear"
-    ],
     "requirement": [
       "§6- 64x Purple Candy",
       "§6- 6x Ectoplasm"
@@ -355,9 +352,6 @@
     "z": -815
   },
   "Plumber Joe": {
-    "callNames": [
-      "plumber"
-    ],
     "requirement": [
       "§7- No Requirement"
     ],
@@ -518,9 +512,6 @@
     "z": -35
   },
   "Wool Weaver": {
-    "callNames": [
-      "wool"
-    ],
     "requirement": [
       "§6- 512x Enchanted Wool."
     ],

--- a/constants/abiphone.json
+++ b/constants/abiphone.json
@@ -150,6 +150,10 @@
     "z": -43
   },
   "Fred": {
+    "callNames": [
+      "forge",
+      "fred"
+    ],
     "requirement": [
       "§6- 64x Foul Flesh"
     ],

--- a/constants/abiphone.json
+++ b/constants/abiphone.json
@@ -306,6 +306,10 @@
     "z": -34
   },
   "Mort": {
+    "callNames": [
+      "dungeon",
+      "mort"
+    ],
     "requirement": [
       "§6- 1x Saving Grace",
       "§6- 1x Spirit Mask"

--- a/constants/abiphone.json
+++ b/constants/abiphone.json
@@ -73,6 +73,9 @@
     "z": -27
   },
   "Captain Ahone": {
+    "callNames": [
+      "ahone"
+    ],
     "requirement": [
       "§6- Part of Mage Faction Quest"
     ]
@@ -137,6 +140,9 @@
     "z": -88
   },
   "Fear Mongerer": {
+    "callNames": [
+      "fear"
+    ],
     "requirement": [
       "§6- 64x Purple Candy",
       "§6- 6x Ectoplasm"
@@ -217,6 +223,9 @@
     "z": -134
   },
   "Jotraeline Greatforge": {
+    "callNames": [
+      "jotraeline"
+    ],
     "requirement": [
       "§6- §fCommon §6or",
       "§6- §aUncommon §6Abiphone"
@@ -254,6 +263,9 @@
     "z": -642
   },
   "Kuudra Gatekeeper": {
+    "callNames": [
+      "kuudra"
+    ],
     "requirement": [
       "§6- 1x Blazing Resistance IV Attribute Shard."
     ],
@@ -263,6 +275,9 @@
     "z": -1037
   },
   "Lumber Merchant": {
+    "callNames": [
+      "lumber"
+    ],
     "requirement": [
       "§6- 1x Jungle Axe."
     ],
@@ -272,6 +287,10 @@
     "z": -69
   },
   "Maddox the Slayer": {
+    "callNames": [
+      "maddox",
+      "slayer"
+    ],
     "requirement": [
       "§6- 1x Maddox Batphone"
     ],
@@ -336,6 +355,9 @@
     "z": -815
   },
   "Plumber Joe": {
+    "callNames": [
+      "plumber"
+    ],
     "requirement": [
       "§7- No Requirement"
     ],
@@ -345,6 +367,9 @@
     "z": -78
   },
   "Queen Mismyla": {
+    "callNames": [
+      "mismyla"
+    ],
     "requirement": [
       "§6- 1x Royal Pigeon"
     ],
@@ -354,6 +379,9 @@
     "z": 195
   },
   "Queen Nyx": {
+    "callNames": [
+      "nyx"
+    ],
     "requirement": [
       "§6- §512,000ቾ Mage Reputation"
     ],
@@ -418,6 +446,9 @@
     "z": 176
   },
   "St. Jerry": {
+    "callNames": [
+      "stjerry"
+    ],
     "requirement": [
       "§6Type the following sentence in chat in front of him:",
       "§bI love the warmth of the Holidays despite the snow"
@@ -437,6 +468,9 @@
     "z": -706
   },
   "Tia the Fairy": {
+    "callNames": [
+      "tia"
+    ],
     "requirement": [
       "§6- Wear a full set of Fairy Armor."
     ],
@@ -484,6 +518,9 @@
     "z": -35
   },
   "Wool Weaver": {
+    "callNames": [
+      "wool"
+    ],
     "requirement": [
       "§6- 512x Enchanted Wool."
     ],


### PR DESCRIPTION
Adds Abiphone `/call` names to some NPCs for an upcoming Skyblocker feature that will use them.

If an NPC has no `callNames` field then the call name is presumed to be the NPC's name converted to lowercase with all whitespace removed. Overrides are generally the most reasonable names that someone might use to find the NPC. Note that it is not a goal to list all call names for every NPC, doing so is unnecessary and excessive for the use cases this has (e.g. Brigadier autocomplete or some kind of a call GUI).