### PR TITLE
Fix: wrong shard for sale in ELIZABETH_NPC.json

### DIFF
--- a/items/ELIZABETH_NPC.json
+++ b/items/ELIZABETH_NPC.json
@@ -402,7 +402,7 @@
       "cost": [
         "SKYBLOCK_BIT:5000"
       ],
-      "result": "ATTRIBUTE_SHARD_DWARVEN_SERENDIPITY;1"
+      "result": "ATTRIBUTE_SHARD_COOKIE_EATER;1"
     }
   ]
 }


### PR DESCRIPTION
ATTRIBUTE_SHARD_DWARVEN_SERENDIPITY;1 -> ATTRIBUTE_SHARD_COOKIE_EATER;1