### PR TITLE
fix: missing call names in abiphone contacts

### DIFF
--- a/constants/abiphone.json
+++ b/constants/abiphone.json
@@ -1,5 +1,8 @@
 {
   "Alchemist": {
+    "callNames": [
+      "alchemist"
+    ],
     "requirement": [
       "§6- 64x Mutant Nether Wart."
     ],
@@ -9,6 +12,9 @@
     "z": -64
   },
   "Alda": {
+    "callNames": [
+      "alda"
+    ],
     "requirement": [
       "§7- No Requirement"
     ],
@@ -18,6 +24,9 @@
     "z": -60
   },
   "Alixer": {
+    "callNames": [
+      "alixer"
+    ],
     "requirement": [
       "§6- Have at least 4 Bingo Goals completed."
     ],
@@ -27,6 +36,9 @@
     "z": -94
   },
   "Anita": {
+    "callNames": [
+      "anita"
+    ],
     "requirement": [
       "§6- Have Jacob's contact",
       "§6- 1x Gold Medal"
@@ -37,6 +49,9 @@
     "z": -70
   },
   "Aranya": {
+    "callNames": [
+      "aranya"
+    ],
     "requirement": [
       "§7- No Requirement"
     ],
@@ -46,6 +61,9 @@
     "z": -1007
   },
   "Bingo": {
+    "callNames": [
+      "bingo"
+    ],
     "requirement": [
       "§7- No Requirement."
     ],
@@ -55,6 +73,9 @@
     "z": -92
   },
   "Blacksmith": {
+    "callNames": [
+      "blacksmith"
+    ],
     "requirement": [
       "§6- 32.000.000 Coins"
     ],
@@ -64,6 +85,9 @@
     "z": -125
   },
   "Brynmor": {
+    "callNames": [
+      "brynmor"
+    ],
     "requirement": [
       "§6- 1x Speckled Teacup"
     ],
@@ -73,6 +97,10 @@
     "z": -155
   },
   "Builder": {
+    "callNames": [
+      "builder",
+      "build"
+    ],
     "requirement": [
       "§61x Builder's Wand."
     ],
@@ -83,6 +111,8 @@
   },
   "Captain Ahone": {
     "callNames": [
+      "captainahone",
+      "captain",
       "ahone"
     ],
     "requirement": [
@@ -90,6 +120,9 @@
     ]
   },
   "Dean": {
+    "callNames": [
+      "dean"
+    ],
     "requirement": [
       "§6- Part of Mage Faction Quest"
     ],
@@ -99,11 +132,17 @@
     "z": -882
   },
   "Duncan": {
+    "callNames": [
+      "duncan"
+    ],
     "requirement": [
       "§7- No Requirement."
     ]
   },
   "Dusk": {
+    "callNames": [
+      "dusk"
+    ],
     "requirement": [
       "§6- Kill a Runic Enderman."
     ],
@@ -113,6 +152,10 @@
     "z": -126
   },
   "Elizabeth": {
+    "callNames": [
+      "elizabeth",
+      "beth"
+    ],
     "requirement": [
       "§6- 1x Abiphone Contacts Trio"
     ],
@@ -122,6 +165,9 @@
     "z": -101
   },
   "Einary": {
+    "callNames": [
+      "einary"
+    ],
     "requirement": [
       "§6- 1x Einary's Red Hoodie"
     ],
@@ -131,6 +177,9 @@
     "z": 63
   },
   "Elle": {
+    "callNames": [
+      "elle"
+    ],
     "requirement": [
       "§6- Part of Mage Faction Quest"
     ],
@@ -140,6 +189,9 @@
     "z": -476
   },
   "Fann": {
+    "callNames": [
+      "fann"
+    ],
     "requirement": [
       "§6- Give 1x Bat the Fish to Hootie"
     ],
@@ -149,6 +201,10 @@
     "z": -88
   },
   "Fear Mongerer": {
+    "callNames": [
+      "fearmongerer",
+      "fear"
+    ],
     "requirement": [
       "§6- 64x Purple Candy",
       "§6- 6x Ectoplasm"
@@ -160,6 +216,7 @@
   },
   "Fred": {
     "callNames": [
+      "foreman",
       "forge",
       "fred"
     ],
@@ -172,6 +229,9 @@
     "z": -68
   },
   "Geo": {
+    "callNames": [
+      "geo"
+    ],
     "requirement": [
       "§6Flawless Gemstones in the following order:",
       "§6- §cRuby",
@@ -187,6 +247,9 @@
     "z": -115
   },
   "George": {
+    "callNames": [
+      "george"
+    ],
     "requirement": [
       "§6"
     ],
@@ -196,6 +259,9 @@
     "z": -101
   },
   "Hoppity": {
+    "callNames": [
+      "hoppity"
+    ],
     "requirement": [
       "§6- 1x Fish Chocolat à la Vapeur"
     ],
@@ -205,6 +271,9 @@
     "z": 8
   },
   "Igrupan": {
+    "callNames": [
+      "igrupan"
+    ],
     "requirement": [
       "§7- No Requirement"
     ],
@@ -214,6 +283,9 @@
     "z": -824
   },
   "Jacob": {
+    "callNames": [
+      "jacob"
+    ],
     "requirement": [
       "§6- 10x Jacob's Ticket"
     ],
@@ -223,6 +295,9 @@
     "z": -68
   },
   "Jax": {
+    "callNames": [
+      "jax"
+    ],
     "requirement": [
       "§6- 10,000,000 Coins or",
       "§6- Clear §cTarget Practice IV"
@@ -234,6 +309,7 @@
   },
   "Jotraeline Greatforge": {
     "callNames": [
+      "jotraelinegreatforge",
       "jotraeline"
     ],
     "requirement": [
@@ -246,6 +322,10 @@
     "z": -19
   },
   "Kat": {
+    "callNames": [
+      "kat",
+      "cat"
+    ],
     "requirement": [
       "§6- 1x Kat Flower"
     ],
@@ -255,6 +335,9 @@
     "z": -100
   },
   "Kiara": {
+    "callNames": [
+      "kiara"
+    ],
     "requirement": [
       "§6- 1x Chameleon Shard"
     ],
@@ -264,6 +347,9 @@
     "z": -70
   },
   "Kaus": {
+    "callNames": [
+      "kaus"
+    ],
     "requirement": [
       "§7- No Requirement"
     ],
@@ -274,6 +360,7 @@
   },
   "Kuudra Gatekeeper": {
     "callNames": [
+      "kuudragatekeeper",
       "kuudra"
     ],
     "requirement": [
@@ -286,6 +373,7 @@
   },
   "Lumber Merchant": {
     "callNames": [
+      "lumbermerchant",
       "lumber"
     ],
     "requirement": [
@@ -298,6 +386,7 @@
   },
   "Maddox the Slayer": {
     "callNames": [
+      "maddoxtheslayer",
       "maddox",
       "slayer"
     ],
@@ -310,6 +399,9 @@
     "z": -50
   },
   "Maxwell": {
+    "callNames": [
+      "maxwell"
+    ],
     "requirement": [
       "§6- 2x Ultimate Carrot Candies"
     ],
@@ -333,6 +425,9 @@
     "z": 0
   },
   "Odger": {
+    "callNames": [
+      "odger"
+    ],
     "requirement": [
       "§6- 1x Any Diamond Trophy Fish."
     ],
@@ -342,6 +437,9 @@
     "z": -810
   },
   "Ophelia": {
+    "callNames": [
+      "ophelia"
+    ],
     "requirement": [
       "§6- 1x Catacombs Expert Ring"
     ],
@@ -351,6 +449,9 @@
     "z": -6
   },
   "Oringo": {
+    "callNames": [
+      "oringo"
+    ],
     "requirement": [
       "§6- 64x Silent Pearls"
     ],
@@ -360,6 +461,9 @@
     "z": -45
   },
   "Pablo": {
+    "callNames": [
+      "pablo"
+    ],
     "requirement": [
       "§7- No Requirement"
     ],
@@ -369,6 +473,11 @@
     "z": -815
   },
   "Plumber Joe": {
+    "callNames": [
+      "plumberjoe",
+      "plumber",
+      "joe"
+    ],
     "requirement": [
       "§7- No Requirement"
     ],
@@ -379,6 +488,7 @@
   },
   "Queen Mismyla": {
     "callNames": [
+      "queenmismyla",
       "mismyla"
     ],
     "requirement": [
@@ -391,6 +501,7 @@
   },
   "Queen Nyx": {
     "callNames": [
+      "queennyx",
       "nyx"
     ],
     "requirement": [
@@ -402,6 +513,9 @@
     "z": -755
   },
   "Roddy": {
+    "callNames": [
+      "roddy"
+    ],
     "requirement": [
       "§6- 1x Torn Cloth"
     ],
@@ -411,6 +525,9 @@
     "z": -24
   },
   "Rollim": {
+    "callNames": [
+      "rollim"
+    ],
     "requirement": [
       "§7- No Requirement"
     ],
@@ -420,6 +537,10 @@
     "z": -853
   },
   "Rusty": {
+    "callNames": [
+      "rusty",
+      "janitor"
+    ],
     "requirement": [
       "§7- No Requirement"
     ],
@@ -429,6 +550,9 @@
     "z": -325
   },
   "Shifty": {
+    "callNames": [
+      "shifty"
+    ],
     "requirement": [
       "§6- 1x Scarleton Premium",
       "§6- 1x Red Thornleaf Tea"
@@ -439,6 +563,9 @@
     "z": 174
   },
   "Sirih": {
+    "callNames": [
+      "sirih"
+    ],
     "requirement": [
       "§7- No Requirement."
     ],
@@ -448,6 +575,9 @@
     "z": -887
   },
   "Sirius": {
+    "callNames": [
+      "sirih"
+    ],
     "requirement": [
       "§6- 1x Sirius' Personal Phone Number"
     ],
@@ -470,6 +600,9 @@
     "z": 92
   },
   "Suus": {
+    "callNames": [
+      "suus"
+    ],
     "requirement": [
       "§7- No Requirement."
     ],
@@ -480,6 +613,8 @@
   },
   "Tia the Fairy": {
     "callNames": [
+      "tiathefairy",
+      "fairy",
       "tia"
     ],
     "requirement": [
@@ -491,11 +626,17 @@
     "z": 137
   },
   "Tomioka": {
+    "callNames": [
+      "tomioka"
+    ],
     "requirement": [
       "§6- 1x Titanic Experience Bottle."
     ]
   },
   "Trevor": {
+    "callNames": [
+      "trevor"
+    ],
     "requirement": [
       "§6- 24x Pelts",
       "§6- 1,000,000 Coins"
@@ -506,11 +647,17 @@
     "z": -542
   },
   "Trinity": {
+    "callNames": [
+      "trinity"
+    ],
     "requirement": [
       "§6- 2x Revive Stones."
     ]
   },
   "Vincent": {
+    "callNames": [
+      "vincent"
+    ],
     "requirement": [
       "§6- 1x Mole Pet."
     ],
@@ -520,6 +667,9 @@
     "z": -102
   },
   "Walter": {
+    "callNames": [
+      "walter"
+    ],
     "requirement": [
       "§6- 1x Enchanted Sulphur Cube. (Must be Sulphur VII Collection or higher.)"
     ],
@@ -529,6 +679,11 @@
     "z": -35
   },
   "Wool Weaver": {
+    "callNames": [
+      "woolweaver",
+      "wool",
+      "weaver"
+    ],
     "requirement": [
       "§6- 512x Enchanted Wool."
     ],
@@ -538,6 +693,9 @@
     "z": -30
   },
   "Zog": {
+    "callNames": [
+      "zog"
+    ],
     "requirement": [
       "§6- Five Max Lvl Pets of Legendary tier or better in your pet menu."
     ],


### PR DESCRIPTION
Added every call name i could find (manually, did some guessing lol)
Seems like it was assumed that NPC names are valid call names. I am not sure, but seems like they are not, and contacts like "Captain Ahone" worked only because first words is captain. So "Alchemist" now has "alchemist" as her call name

Btw, did you know Kat can be referred to as cat?