### PR TITLE
feat: change skyblock_bit display name color

### DIFF
--- a/items/SKYBLOCK_BIT.json
+++ b/items/SKYBLOCK_BIT.json
@@ -1,6 +1,6 @@
 {
   "itemid": "minecraft:skull",
-  "displayname": "§aBit",
+  "displayname": "§bBit",
   "nbttag": "{ExtraAttributes:{id:\"SKYBLOCK_BIT\"},HideFlags:254,ItemModel:\"minecraft:player_head\",SkullOwner:{Id:\"8cf0debb-5716-54a5-8c7a-bed9ea0a2941\",Properties:{textures:[0:{Name:\"textures\",Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGExNDg0ZjVjNTQ1OGEzYWRhNTk0YTUyOGI2NWJmOWE5ZDU3N2UyNWIyNzE3ZGE3ODY0NjFjOWI2NTg4YjQ4In19fQ==\"}]},hypixelPopulated:1B},display:{Lore:[0:\"§7Used for NEU NPC-Shops\",1:\"\",2:\"§c§l§ka§r §c§lSPECIAL §c§l§ka\"],Name:\"§aBit\"}}",
   "damage": 3,
   "lore": [


### PR DESCRIPTION
Changed from green to cyan to match in-game colors