### PR TITLE
fix cow minion t11 recipe

### DIFF
--- a/items/COW_GENERATOR_11.json
+++ b/items/COW_GENERATOR_11.json
@@ -24,15 +24,15 @@
     "https://wiki.hypixel.net/Cow_Minion_XI"
   ],
   "recipe": {
-    "A1": "ENCHANTED_LEATHER:32",
-    "A2": "ENCHANTED_LEATHER:32",
-    "A3": "ENCHANTED_LEATHER:32",
-    "B1": "ENCHANTED_LEATHER:32",
+    "A1": "ENCHANTED_LEATHER:64",
+    "A2": "ENCHANTED_LEATHER:64",
+    "A3": "ENCHANTED_LEATHER:64",
+    "B1": "ENCHANTED_LEATHER:64",
     "B2": "COW_GENERATOR_10:1",
-    "B3": "ENCHANTED_LEATHER:32",
-    "C1": "ENCHANTED_LEATHER:32",
-    "C2": "ENCHANTED_LEATHER:32",
-    "C3": "ENCHANTED_LEATHER:32"
+    "B3": "ENCHANTED_LEATHER:64",
+    "C1": "ENCHANTED_LEATHER:64",
+    "C2": "ENCHANTED_LEATHER:64",
+    "C3": "ENCHANTED_LEATHER:64"
   },
   "useneucraft": true
 }


### PR DESCRIPTION
The cow minion t11 requires 512 enchanted leather to craft and not 256 (screenshot of /viewrecipe COW_GENERATOR_11 attached)
<img width="1147" height="635" alt="image" src="https://github.com/user-attachments/assets/0494a043-78e5-4ac4-8f04-2b7b8b972bf5" />
