### PR TITLE
ci: add comment on PR when workflow fails

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -56,11 +56,11 @@ jobs:
     if: failure() && github.event_name == 'pull_request'
     steps:
       - name: Save PR Number
+        run: "echo $PR_NUMBER > ${{ runner.temp }}/pr-number"
         env:
           PR_NUMBER: ${{ github.event.number }}
-        run: |
-          echo $PR_NUMBER > ${{ runner.temp }}/pr-number
-      - uses: actions/upload-artifact@v7
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v7
         with:
           name: pr-number
           archive: 'false'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    name: Check
     if: ${{ '247692460' == github.repository_id || 'workflow_dispatch' == github.event_name }}
     steps:
       - name: Find HEAD Ref
@@ -47,3 +48,20 @@ jobs:
           REPO_BASE_PATH: ${{ github.workspace }}/repo
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
+
+  save_pr:
+    runs-on: ubuntu-latest
+    name: Log Failure
+    needs: check
+    if: failure() && github.event_name == 'pull_request'
+    steps:
+      - name: Save PR Number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > ${{ runner.temp }}/pr-number
+      - uses: actions/upload-artifact@v7
+        with:
+          name: pr-number
+          archive: 'false'
+          path: ${{ runner.temp }}/pr-number

--- a/.github/workflows/comment_failure.yml
+++ b/.github/workflows/comment_failure.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   comment_failure:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request' &&  github.event.workflow_run.conclusion == 'failure'
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure'
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/comment_failure.yml
+++ b/.github/workflows/comment_failure.yml
@@ -1,0 +1,58 @@
+name: Comment Failure
+on:
+  workflow_run:
+    workflows: [ "Check Files" ]
+    types: [ completed ]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment_failure:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' &&  github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-number
+          path: ${{ runner.temp }}/artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GH_PAT }}
+      - name: Find Job ID
+        id: job-id
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const response = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id}}
+            });
+            const job = response.data.jobs.find(job => job.name === 'Check');
+            if (job == null) throw new Error('Failed to find Job ID');
+            return job.id;
+      - name: Comment on PR
+        uses: actions/github-script@v9
+        with:
+          script: |
+            // Boilerplate code to get PR Number from artifact
+            const fs = require('fs');
+            const path = require('path');
+            const file = '${{ runner.temp }}/artifact/pr-number';
+            const issue_number_raw = fs.readFileSync(file, 'utf8').trim();
+            const issue_number = Number(issue_number_raw);
+            if (!Number.isInteger(issue_number)) {
+              throw new Error(`Invalid PR number in pr_number artifact: "${issue_number_raw}"`);
+            }
+            
+            const baseUrl = "${{ github.event.workflow_run.html_url }}";
+            const summaryUrl = baseUrl + "/attempts/${{ github.event.workflow_run.run_attempt }}/#summary-${{ steps.job-id.outputs.result }}";
+            const logUrl = baseUrl + "/job/${{ steps.job-id.outputs.result }}";
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: `I've detected some problems you might want to take a look at, you can see them in the [Workflow Summary](${summaryUrl}) or [Workflow Log](${logUrl}).`
+            });


### PR DESCRIPTION
Requires a [fine-grained PAT](https://github.com/settings/personal-access-tokens/new) with "Actions: read" permission (scope to this repository only) to be added as a secret named `GH_PAT`. (GitHub doesn't give an easy way to get the PR number from a failed action, so they have you upload it as an artifact but an action can only read its own artifacts with its token so you have to provide your own token 💀)

Example of message:
<img width="933" height="155" alt="image" src="https://github.com/user-attachments/assets/c905a48a-6cc0-4422-8f3f-aea021b3c6ff" />
