### PR TITLE
Add SkyBlock Menu common tooltip style

### DIFF
--- a/itemsOverlay/4671/SKYBLOCK_MENU.snbt
+++ b/itemsOverlay/4671/SKYBLOCK_MENU.snbt
@@ -18,7 +18,8 @@
 				"minecraft:block_entity_data",
 				"minecraft:dyed_color"
 			]
-		}
+		},
+		"minecraft:tooltip_style": "hypixel_skyblock:common"
 	},
 	count: 1,
 	id: "minecraft:nether_star",


### PR DESCRIPTION
According to its tooltip style it is a common item. I only noticed this because it now has a rarity background in Skyblocker since we added tooltip style detection as a fallback.