### PR TITLE
ci: ignore faction rabbits in wiki link updates

### DIFF
--- a/.github/scripts/updateWikiLinks.py
+++ b/.github/scripts/updateWikiLinks.py
@@ -76,6 +76,9 @@ class WikiLinkUpdater:
         if file.data["itemid"] == "minecraft:potion":
             return False
 
+        if "FACTION_RABBIT" in file.data["internalname"]:
+            return False
+
         existingInfo = file.data.get("info", [])
         validLinks = [
             link for link in existingInfo if link.startswith(urlPrefix)


### PR DESCRIPTION
since they share names with other real things, it will give wrong results